### PR TITLE
add base url environment variable so auth router redirect works

### DIFF
--- a/backend/app/features/auth/auth_router.py
+++ b/backend/app/features/auth/auth_router.py
@@ -30,9 +30,9 @@ class OpenIdCallbackParams(BaseModel):
 
 
 @auth_router.get("/api/auth/steam")
-def auth_with_steam():
-    return_url = "http://localhost:5173/api/auth/steam/callback"
-    realm = "http://localhost:5173/"
+def auth_with_steam(settings: AppSettings):
+    return_url = f"{settings.base_url}/api/auth/steam/callback"
+    realm = f"{settings.base_url}/"
 
     query_params: QueryParams = QueryParams(
         {

--- a/backend/app/settings.py
+++ b/backend/app/settings.py
@@ -2,6 +2,7 @@ from functools import lru_cache
 from typing import Annotated
 
 from fastapi import Depends
+from pydantic import field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -15,6 +16,13 @@ class Settings(BaseSettings):
     twitch_client_id: str
     twitch_client_secret: str
     steam_api_key: str
+
+    base_url: str = "http://localhost:5173"
+
+    @field_validator("base_url")
+    @classmethod
+    def strip_trailing_slash(cls, v: str) -> str:
+        return v.rstrip("/")
 
 
 @lru_cache

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>frontend</title>
+    <title>Backlog Boss</title>
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
This pull request introduces improvements to the configuration and flexibility of the authentication flow, particularly for Steam, by making the base URL configurable and ensuring it is consistently formatted. Additionally, there is a minor frontend update to the application's title.

**Backend: Authentication and Configuration Improvements**
* Made the `base_url` configurable in the `Settings` class, with a default value of `"http://localhost:5173"`, and added a validator to strip any trailing slash to ensure consistent URL formatting. (`backend/app/settings.py`)
* Updated the Steam authentication endpoint to use the configurable `base_url` from settings instead of a hardcoded value, making the callback and realm URLs environment-agnostic. (`backend/app/features/auth/auth_router.py`)

**Frontend: Minor Update**
* Changed the HTML `<title>` from "frontend" to "Backlog Boss" to reflect the application's name. (`frontend/index.html`)