### PR TITLE
adjust publish image so that it can check out a tag without failing

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -21,7 +21,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          fetch-tags: true
+          ref: ${{ github.ref }}
+          fetch-depth: 0
 
       - name: Log in to the Container registry
         uses: docker/login-action@v3


### PR DESCRIPTION
This pull request makes a small update to the GitHub Actions workflow for publishing images. The checkout step is updated to check out the specific ref associated with the workflow run and to fetch the full history.

* Updated the `actions/checkout` step in `.github/workflows/publish-image.yml` to use the current GitHub ref and set `fetch-depth: 0` for a complete history checkout.