### PR TITLE
search igdb for games even if there are already games found in db

### DIFF
--- a/backend/app/features/game/persist_igdb_games.py
+++ b/backend/app/features/game/persist_igdb_games.py
@@ -5,9 +5,9 @@ from app.database.models import IgdbExternalGame, IgdbGame, IgdbGameTimeToBeat
 from app.infrastructure.igdb_client import IgdbGameResponse
 
 
-def persist_igdb_games(db: Session, games: list[IgdbGameResponse]) -> None:
+def persist_igdb_games(db: Session, games: list[IgdbGameResponse]) -> bool:
     if not games:
-        return
+        return False
 
     game_ids = [game.id for game in games]
     existing_game_ids = set(
@@ -70,10 +70,11 @@ def persist_igdb_games(db: Session, games: list[IgdbGameResponse]) -> None:
         games_to_add.append(igdb_game)
 
     if not games_to_add:
-        return
+        return False
 
     db.add_all(games_to_add)
     db.flush()
+    return True
 
 
 def _parse_external_uid(uid: str) -> int | None:

--- a/backend/app/features/game/search_games_handler.py
+++ b/backend/app/features/game/search_games_handler.py
@@ -36,22 +36,25 @@ class SearchGamesHandler:
             )
 
         database_games = self._search_database(normalized_query)
-        if database_games:
-            return SearchGamesResponse(
-                games=[self._build_game_search_row(game) for game in database_games]
-            )
+        db_game_ids = {game.igdb_game_id for game in database_games}
+        db_game_rows = [self._build_game_search_row(game) for game in database_games]
 
         igdb_games = self.igdb_client.search_games_by_name(normalized_query)
         persist_igdb_games(self.db, igdb_games)
         if igdb_games:
             self.db.commit()
-        if not igdb_games:
-            return SearchGamesResponse(games=[])
 
-        persisted_games = self._load_games_by_ids([game.id for game in igdb_games])
-        return SearchGamesResponse(
-            games=[self._build_game_search_row(game) for game in persisted_games]
-        )
+        new_igdb_game_ids = [
+            game.id for game in igdb_games if game.id not in db_game_ids
+        ]
+        new_igdb_rows: list[GameSearchRow] = []
+        if new_igdb_game_ids:
+            new_igdb_games = self._load_games_by_ids(new_igdb_game_ids)
+            new_igdb_rows = [
+                self._build_game_search_row(game) for game in new_igdb_games
+            ]
+
+        return SearchGamesResponse(games=[*db_game_rows, *new_igdb_rows])
 
     def _search_database(self, query: str) -> list[IgdbGame]:
         normalized_query = query.lower()

--- a/backend/app/features/game/search_games_handler.py
+++ b/backend/app/features/game/search_games_handler.py
@@ -40,8 +40,7 @@ class SearchGamesHandler:
         db_game_rows = [self._build_game_search_row(game) for game in database_games]
 
         igdb_games = self.igdb_client.search_games_by_name(normalized_query)
-        persist_igdb_games(self.db, igdb_games)
-        if igdb_games:
+        if persist_igdb_games(self.db, igdb_games):
             self.db.commit()
 
         new_igdb_game_ids = [

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -24,6 +24,11 @@ dev = [
     "testcontainers[mssql]>=4.14.2",
 ]
 
+[tool.pytest.ini_options]
+filterwarnings = [
+    "ignore:The @wait_container_is_ready decorator is deprecated",
+]
+
 [tool.coverage.run]
 source = ["app"]
 

--- a/backend/tests/features/game/test_search_games_handler.py
+++ b/backend/tests/features/game/test_search_games_handler.py
@@ -33,7 +33,7 @@ def _create_current_user(db_session: Session) -> User:
     )
 
 
-def test_handle_returns_database_matches_without_calling_igdb(
+def test_handle_returns_database_matches_and_still_calls_igdb(
     db_session: Session,
     mocker: MockerFixture,
 ):
@@ -65,13 +65,14 @@ def test_handle_returns_database_matches_without_calling_igdb(
     db_session.commit()
 
     igdb_client = mocker.Mock()
+    igdb_client.search_games_by_name.return_value = []
 
     actual = SearchGamesHandler(db_session, igdb_client).handle("portal")
 
     assert [(row.game_id, row.title, row.time_to_beat) for row in actual.games] == [
         (10, "Portal 2", 28800),
     ]
-    igdb_client.search_games_by_name.assert_not_called()
+    igdb_client.search_games_by_name.assert_called_once_with("portal")
 
 
 def test_handle_fetches_from_igdb_persists_results_and_returns_them(
@@ -158,6 +159,7 @@ def test_handle_limits_database_matches_to_fifty(
     db_session.commit()
 
     igdb_client = mocker.Mock()
+    igdb_client.search_games_by_name.return_value = []
 
     actual = SearchGamesHandler(db_session, igdb_client).handle("portal")
 
@@ -165,7 +167,58 @@ def test_handle_limits_database_matches_to_fifty(
     assert [row.title for row in actual.games] == [
         f"Portal {game_id:03d}" for game_id in range(1, 51)
     ]
-    igdb_client.search_games_by_name.assert_not_called()
+    igdb_client.search_games_by_name.assert_called_once_with("portal")
+
+
+def test_handle_merges_db_and_igdb_results_with_deduplication(
+    db_session: Session,
+    mocker: MockerFixture,
+):
+    _create_current_user(db_session)
+    existing_game = IgdbGame(igdb_game_id=100, name="Half-Life 2", total_rating=96.0)
+    existing_game.external_games.append(
+        IgdbExternalGame(
+            igdb_external_game_id=501,
+            uid=220,
+            igdb_external_game_source_id=1,
+        )
+    )
+    db_session.add(existing_game)
+    db_session.commit()
+
+    igdb_client = mocker.Mock()
+    igdb_client.search_games_by_name.return_value = [
+        IgdbGameResponse(
+            id=100,
+            name="Half-Life 2",
+            total_rating=96.0,
+            external_games=[
+                ExternalGameResponse(
+                    id=501, game=100, uid="220", external_game_source=1
+                )
+            ],
+            time_to_beat=None,
+        ),
+        IgdbGameResponse(
+            id=200,
+            name="Half-Life: Alyx",
+            total_rating=92.0,
+            external_games=[
+                ExternalGameResponse(
+                    id=502, game=200, uid="546560", external_game_source=1
+                )
+            ],
+            time_to_beat=TimeToBeatResponse(id=601, game_id=200, normally=43200),
+        ),
+    ]
+
+    actual = SearchGamesHandler(db_session, igdb_client).handle("half-life")
+
+    assert [(row.game_id, row.title, row.time_to_beat) for row in actual.games] == [
+        (100, "Half-Life 2", None),
+        (200, "Half-Life: Alyx", 43200),
+    ]
+    igdb_client.search_games_by_name.assert_called_once_with("half-life")
 
 
 def test_handle_raises_for_blank_queries(

--- a/frontend/src/pages/games/GamesView.tsx
+++ b/frontend/src/pages/games/GamesView.tsx
@@ -1,11 +1,11 @@
 import SearchIcon from "@mui/icons-material/Search";
 import ScheduleIcon from "@mui/icons-material/Schedule";
-import SportsEsportsIcon from "@mui/icons-material/SportsEsports";
 import StarIcon from "@mui/icons-material/Star";
 import Alert from "@mui/material/Alert";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
 import Chip from "@mui/material/Chip";
+import CircularProgress from "@mui/material/CircularProgress";
 import Divider from "@mui/material/Divider";
 import List from "@mui/material/List";
 import ListItem from "@mui/material/ListItem";
@@ -84,7 +84,7 @@ export function GamesView({
                 variant="contained"
                 size="large"
                 disabled={isSearchDisabled}
-                startIcon={<SearchIcon />}
+                startIcon={isPending ? <CircularProgress size={20} color="inherit" /> : <SearchIcon />}
                 sx={{ minWidth: { md: 180 } }}
               >
                 {isPending ? "Searching…" : "Search"}
@@ -121,12 +121,18 @@ export function GamesView({
           variant="outlined"
           sx={{ p: 3, borderRadius: 3, bgcolor: "background.paper" }}
         >
-          <Typography variant="h6" gutterBottom>
-            Searching for "{submittedQuery}"
-          </Typography>
-          <Typography color="text.secondary">
-            Pulling matching games from the local catalog and IGDB if needed.
-          </Typography>
+          <Stack direction="row" spacing={2} sx={{ alignItems: "center" }}>
+            <CircularProgress size={32} />
+            <Box>
+              <Typography variant="h6" gutterBottom>
+                Searching for "{submittedQuery}"
+              </Typography>
+              <Typography color="text.secondary">
+                Pulling matching games from the local catalog and IGDB if
+                needed.
+              </Typography>
+            </Box>
+          </Stack>
         </Paper>
       ) : null}
 
@@ -165,12 +171,6 @@ export function GamesView({
                           }}
                         >
                           <Typography variant="h6">{game.title}</Typography>
-                          <Chip
-                            size="small"
-                            color="primary"
-                            icon={<SportsEsportsIcon />}
-                            label={`IGDB #${game.gameId}`}
-                          />
                         </Stack>
                       }
                       secondary={

--- a/frontend/src/pages/games/GamesView.tsx
+++ b/frontend/src/pages/games/GamesView.tsx
@@ -84,7 +84,13 @@ export function GamesView({
                 variant="contained"
                 size="large"
                 disabled={isSearchDisabled}
-                startIcon={isPending ? <CircularProgress size={20} color="inherit" /> : <SearchIcon />}
+                startIcon={
+                  isPending ? (
+                    <CircularProgress size={20} color="inherit" />
+                  ) : (
+                    <SearchIcon />
+                  )
+                }
                 sx={{ minWidth: { md: 180 } }}
               >
                 {isPending ? "Searching…" : "Search"}


### PR DESCRIPTION
This pull request improves the game search experience by updating both backend and frontend logic. On the backend, it changes how search results are merged and deduplicated between the local database and IGDB, and updates tests to match the new logic. On the frontend, it enhances the user interface by providing clearer loading feedback during searches.

**Backend: Improved search result merging and testing**

* The `SearchGamesHandler` now merges results from the local database and IGDB, deduplicating by IGDB game ID, so users see a unified, non-redundant list of matching games.
* Test cases have been updated and expanded:
  - Tests now expect IGDB to be queried even if database matches exist, and check that deduplication works as intended. [[1]](diffhunk://#diff-e0d5eada9d604bb00003a686f01f9310da0c10a393a9ae2cb21addbeb0a919a4L36-R36) [[2]](diffhunk://#diff-e0d5eada9d604bb00003a686f01f9310da0c10a393a9ae2cb21addbeb0a919a4R68-R75) [[3]](diffhunk://#diff-e0d5eada9d604bb00003a686f01f9310da0c10a393a9ae2cb21addbeb0a919a4R162-R221)
* Adds a pytest warning filter to suppress deprecation warnings during test runs.

**Frontend: Enhanced search feedback and UI simplification**

* The search button and results area now show a `CircularProgress` spinner when a search is in progress, improving user feedback. [[1]](diffhunk://#diff-3fd963c331939d3fd6b337482fe30dfe2b2de60393c3238063ce4e4aba232d3bL87-R87) [[2]](diffhunk://#diff-3fd963c331939d3fd6b337482fe30dfe2b2de60393c3238063ce4e4aba232d3bR124-R135)
* Removes the IGDB ID chip from the game list UI for a cleaner appearance.
* Cleans up unused icon imports in `GamesView.tsx`.