### PR TITLE
Backlog page improvements

### DIFF
--- a/backend/app/features/user/refresh_my_backlog_handler.py
+++ b/backend/app/features/user/refresh_my_backlog_handler.py
@@ -1,0 +1,92 @@
+from fastapi import HTTPException, status
+from sqlalchemy import select
+
+from app.database.engine import DbSession
+from app.database.models import (
+    Backlog,
+    BacklogGame,
+    IgdbExternalGame,
+    IgdbGame,
+)
+from app.features.api_model import ApiResponseModel
+from app.features.auth.get_current_user import CurrentUser
+from app.features.game.persist_igdb_games import persist_igdb_games
+from app.infrastructure.igdb_client import IgdbClientDep
+from app.infrastructure.steam_client import SteamClientDep
+
+
+class RefreshMyBacklogResponse(ApiResponseModel):
+    backlog_id: int
+    games_added_count: int
+
+
+class RefreshMyBacklogHandler:
+    def __init__(
+        self,
+        db: DbSession,
+        steam: SteamClientDep,
+        current_user: CurrentUser,
+        igdb_client: IgdbClientDep,
+    ):
+        self.db = db
+        self.steam = steam
+        self.current_user = current_user
+        self.igdb_client = igdb_client
+
+    def handle(self) -> RefreshMyBacklogResponse:
+        stmt = select(Backlog).where(
+            Backlog.app_user_id == self.current_user.app_user_id
+        )
+        backlog = self.db.scalars(stmt).one_or_none()
+        if not backlog:
+            raise HTTPException(
+                status.HTTP_404_NOT_FOUND,
+                "Backlog not found. Create one first.",
+            )
+
+        owned_games = self.steam.get_owned_games(self.current_user.steam_id)
+        owned_game_steam_ids = {game.steam_game_id for game in owned_games}
+
+        stmt = select(IgdbExternalGame.uid).where(
+            IgdbExternalGame.uid.in_(owned_game_steam_ids)
+        )
+        games_in_db = self.db.scalars(stmt).all()
+        games_in_db_ids = set(games_in_db)
+
+        steam_game_ids_to_insert = owned_game_steam_ids - games_in_db_ids
+
+        if steam_game_ids_to_insert:
+            igdb_games = self.igdb_client.get_games_by_steam_id(
+                steam_game_ids_to_insert
+            )
+            persist_igdb_games(self.db, igdb_games)
+
+        stmt = (
+            select(IgdbGame)
+            .join(IgdbExternalGame)
+            .where(IgdbExternalGame.uid.in_(owned_game_steam_ids))
+            .where(IgdbGame.time_to_beat != None)  # noqa: E711
+            .where(IgdbGame.total_rating != None)  # noqa: E711
+            .distinct()
+        )
+        qualified_games = self.db.scalars(stmt).all()
+        qualified_igdb_game_ids = {g.igdb_game_id for g in qualified_games}
+
+        stmt = select(BacklogGame.igdb_game_id).where(
+            BacklogGame.backlog_id == backlog.backlog_id
+        )
+        existing_igdb_game_ids = set(self.db.scalars(stmt).all())
+
+        to_add_igdb_game_ids = qualified_igdb_game_ids - existing_igdb_game_ids
+
+        new_backlog_games = [
+            BacklogGame(backlog_id=backlog.backlog_id, igdb_game_id=gid)
+            for gid in to_add_igdb_game_ids
+        ]
+        self.db.add_all(new_backlog_games)
+        self.db.commit()
+
+        return RefreshMyBacklogResponse(
+            backlog_id=backlog.backlog_id,
+            games_added_count=len(new_backlog_games),
+        )

--- a/backend/app/features/user/refresh_my_backlog_handler.py
+++ b/backend/app/features/user/refresh_my_backlog_handler.py
@@ -72,6 +72,8 @@ class RefreshMyBacklogHandler:
         qualified_games = self.db.scalars(stmt).all()
         qualified_igdb_game_ids = {g.igdb_game_id for g in qualified_games}
 
+        # Intentionally includes removed_on rows so previously removed games
+        # are treated as "already in backlog" and won't be re-added.
         stmt = select(BacklogGame.igdb_game_id).where(
             BacklogGame.backlog_id == backlog.backlog_id
         )

--- a/backend/app/features/user/user_router.py
+++ b/backend/app/features/user/user_router.py
@@ -9,6 +9,10 @@ from app.features.user.get_my_backlog_handler import (
     GetMyBacklogHandler,
     GetMyBacklogResponse,
 )
+from app.features.user.refresh_my_backlog_handler import (
+    RefreshMyBacklogHandler,
+    RefreshMyBacklogResponse,
+)
 
 user_router = APIRouter(tags=["User"])
 
@@ -29,4 +33,11 @@ def create_my_backlog(
 def get_my_backlog(
     handler: GetMyBacklogHandler = Depends(),
 ) -> GetMyBacklogResponse:
+    return handler.handle()
+
+
+@user_router.post("/api/user/refresh-my-backlog")
+def refresh_my_backlog(
+    handler: RefreshMyBacklogHandler = Depends(),
+) -> RefreshMyBacklogResponse:
     return handler.handle()

--- a/backend/tests/features/user/test_refresh_my_backlog_handler.py
+++ b/backend/tests/features/user/test_refresh_my_backlog_handler.py
@@ -1,0 +1,328 @@
+from datetime import datetime, timezone
+
+import pytest
+from fastapi import HTTPException
+from pytest_mock import MockerFixture
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.database.models import (
+    AppUser,
+    Backlog,
+    BacklogGame,
+    IgdbExternalGame,
+    IgdbGame,
+    IgdbGameTimeToBeat,
+)
+from app.features.auth.get_current_user import User
+from app.features.user.refresh_my_backlog_handler import RefreshMyBacklogHandler
+from app.infrastructure.igdb_client import (
+    ExternalGameResponse,
+    IgdbGameResponse,
+    TimeToBeatResponse,
+)
+from app.infrastructure.steam_client import SteamGame
+
+
+def _create_current_user(db_session: Session) -> User:
+    app_user = AppUser(
+        steam_id="76561198000000000",
+        persona_name="Test Persona",
+        first_name="Test",
+        last_name="User",
+    )
+    db_session.add(app_user)
+    db_session.flush()
+
+    return User(
+        app_user_id=app_user.app_user_id,
+        steam_id=app_user.steam_id,
+        persona_name=app_user.persona_name,
+        first_name=app_user.first_name,
+        last_name=app_user.last_name,
+    )
+
+
+def _create_backlog(db_session: Session, current_user: User) -> Backlog:
+    backlog = Backlog(app_user_id=current_user.app_user_id)
+    db_session.add(backlog)
+    db_session.flush()
+    return backlog
+
+
+def _create_game(
+    db_session: Session,
+    igdb_game_id: int,
+    name: str,
+    steam_uid: int,
+    total_rating: float | None = 90.0,
+    time_to_beat: int | None = 3600,
+) -> IgdbGame:
+    game = IgdbGame(
+        igdb_game_id=igdb_game_id,
+        name=name,
+        total_rating=total_rating,
+    )
+    if time_to_beat is not None:
+        game.time_to_beat = IgdbGameTimeToBeat(
+            igdb_game_time_to_beat_id=igdb_game_id + 100,
+            igdb_game_id=igdb_game_id,
+            normally=time_to_beat,
+        )
+    game.external_games.append(
+        IgdbExternalGame(
+            igdb_external_game_id=igdb_game_id + 1000,
+            uid=steam_uid,
+            igdb_external_game_source_id=1,
+        )
+    )
+    db_session.add(game)
+    db_session.flush()
+    return game
+
+
+def test_handle_raises_not_found_when_backlog_is_missing(
+    db_session: Session,
+    mocker: MockerFixture,
+):
+    current_user = _create_current_user(db_session)
+    steam_client = mocker.Mock()
+    igdb_client = mocker.Mock()
+    handler = RefreshMyBacklogHandler(
+        db_session, steam_client, current_user, igdb_client
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        handler.handle()
+
+    assert exc_info.value.status_code == 404
+    assert exc_info.value.detail == "Backlog not found. Create one first."
+
+
+def test_handle_returns_zero_when_no_new_games_to_add(
+    db_session: Session,
+    mocker: MockerFixture,
+):
+    current_user = _create_current_user(db_session)
+    backlog = _create_backlog(db_session, current_user)
+    game = _create_game(db_session, 1, "Existing Game", 111)
+    backlog_game = BacklogGame(
+        backlog_id=backlog.backlog_id,
+        igdb_game_id=game.igdb_game_id,
+    )
+    db_session.add(backlog_game)
+    db_session.commit()
+
+    steam_client = mocker.Mock()
+    steam_client.get_owned_games.return_value = [SteamGame(steam_game_id=111)]
+    handler = RefreshMyBacklogHandler(
+        db_session, steam_client, current_user, mocker.Mock()
+    )
+
+    actual = handler.handle()
+
+    assert actual.backlog_id == backlog.backlog_id
+    assert actual.games_added_count == 0
+    steam_client.get_owned_games.assert_called_once_with(current_user.steam_id)
+
+
+def test_handle_adds_qualifying_new_game_skips_active_game(
+    db_session: Session,
+    mocker: MockerFixture,
+):
+    current_user = _create_current_user(db_session)
+    backlog = _create_backlog(db_session, current_user)
+    existing_game = _create_game(db_session, 1, "Existing Game", 111)
+    new_game = _create_game(db_session, 2, "New Game", 222)
+    backlog_game = BacklogGame(
+        backlog_id=backlog.backlog_id,
+        igdb_game_id=existing_game.igdb_game_id,
+    )
+    db_session.add(backlog_game)
+    db_session.commit()
+
+    steam_client = mocker.Mock()
+    steam_client.get_owned_games.return_value = [
+        SteamGame(steam_game_id=111),
+        SteamGame(steam_game_id=222),
+    ]
+    handler = RefreshMyBacklogHandler(
+        db_session, steam_client, current_user, mocker.Mock()
+    )
+
+    actual = handler.handle()
+
+    assert actual.backlog_id == backlog.backlog_id
+    assert actual.games_added_count == 1
+
+    backlog_game_ids = db_session.scalars(
+        select(BacklogGame.igdb_game_id).where(
+            BacklogGame.backlog_id == backlog.backlog_id
+        )
+    ).all()
+    assert set(backlog_game_ids) == {1, 2}
+
+
+def test_handle_skips_game_without_rating(
+    db_session: Session,
+    mocker: MockerFixture,
+):
+    current_user = _create_current_user(db_session)
+    backlog = _create_backlog(db_session, current_user)
+    _create_game(
+        db_session,
+        1,
+        "No Rating Game",
+        111,
+        total_rating=None,
+        time_to_beat=3600,
+    )
+    db_session.commit()
+
+    steam_client = mocker.Mock()
+    steam_client.get_owned_games.return_value = [SteamGame(steam_game_id=111)]
+    handler = RefreshMyBacklogHandler(
+        db_session, steam_client, current_user, mocker.Mock()
+    )
+
+    actual = handler.handle()
+
+    assert actual.games_added_count == 0
+
+    backlog_game_ids = db_session.scalars(
+        select(BacklogGame.igdb_game_id).where(
+            BacklogGame.backlog_id == backlog.backlog_id
+        )
+    ).all()
+    assert len(backlog_game_ids) == 0
+
+
+def test_handle_skips_game_without_time_to_beat(
+    db_session: Session,
+    mocker: MockerFixture,
+):
+    current_user = _create_current_user(db_session)
+    backlog = _create_backlog(db_session, current_user)
+    _create_game(
+        db_session,
+        1,
+        "No Time Game",
+        111,
+        total_rating=80.0,
+        time_to_beat=None,
+    )
+    db_session.commit()
+
+    steam_client = mocker.Mock()
+    steam_client.get_owned_games.return_value = [SteamGame(steam_game_id=111)]
+    handler = RefreshMyBacklogHandler(
+        db_session, steam_client, current_user, mocker.Mock()
+    )
+
+    actual = handler.handle()
+
+    assert actual.games_added_count == 0
+
+
+def test_handle_does_not_re_add_removed_game(
+    db_session: Session,
+    mocker: MockerFixture,
+):
+    current_user = _create_current_user(db_session)
+    backlog = _create_backlog(db_session, current_user)
+    game = _create_game(db_session, 1, "Removed Game", 111)
+    backlog_game = BacklogGame(
+        backlog_id=backlog.backlog_id,
+        igdb_game_id=game.igdb_game_id,
+        removed_on=datetime(2026, 4, 11, tzinfo=timezone.utc),
+    )
+    db_session.add(backlog_game)
+    db_session.commit()
+
+    steam_client = mocker.Mock()
+    steam_client.get_owned_games.return_value = [SteamGame(steam_game_id=111)]
+    handler = RefreshMyBacklogHandler(
+        db_session, steam_client, current_user, mocker.Mock()
+    )
+
+    actual = handler.handle()
+
+    assert actual.games_added_count == 0
+
+    backlog_game_ids = db_session.scalars(
+        select(BacklogGame.igdb_game_id).where(
+            BacklogGame.backlog_id == backlog.backlog_id
+        )
+    ).all()
+    assert len(backlog_game_ids) == 1
+
+
+def test_handle_fetches_new_igdb_games_and_adds_qualifying_ones(
+    db_session: Session,
+    mocker: MockerFixture,
+):
+    current_user = _create_current_user(db_session)
+    backlog = _create_backlog(db_session, current_user)
+    existing_game = _create_game(db_session, 1, "Existing Game", 111)
+    backlog_game = BacklogGame(
+        backlog_id=backlog.backlog_id,
+        igdb_game_id=existing_game.igdb_game_id,
+    )
+    db_session.add(backlog_game)
+    db_session.commit()
+
+    steam_client = mocker.Mock()
+    steam_client.get_owned_games.return_value = [
+        SteamGame(steam_game_id=111),
+        SteamGame(steam_game_id=222),
+        SteamGame(steam_game_id=333),
+    ]
+    igdb_client = mocker.Mock()
+    igdb_client.get_games_by_steam_id.return_value = [
+        IgdbGameResponse(
+            id=2,
+            name="New Complete Game",
+            total_rating=91.0,
+            external_games=[
+                ExternalGameResponse(
+                    id=2001,
+                    game=2,
+                    uid="222",
+                    external_game_source=1,
+                ),
+                ExternalGameResponse(
+                    id=2002,
+                    game=2,
+                    uid="222,223",
+                    external_game_source=1,
+                ),
+            ],
+            time_to_beat=TimeToBeatResponse(id=3001, game_id=2, normally=7200),
+        ),
+        IgdbGameResponse(
+            id=3,
+            name="New Incomplete Game",
+            total_rating=63.0,
+            external_games=[
+                ExternalGameResponse(id=2003, game=3, uid="333", external_game_source=1)
+            ],
+            time_to_beat=None,
+        ),
+    ]
+    handler = RefreshMyBacklogHandler(
+        db_session, steam_client, current_user, igdb_client
+    )
+
+    actual = handler.handle()
+
+    assert actual.backlog_id == backlog.backlog_id
+    assert actual.games_added_count == 1
+
+    igdb_client.get_games_by_steam_id.assert_called_once_with({222, 333})
+
+    backlog_game_ids = db_session.scalars(
+        select(BacklogGame.igdb_game_id).where(
+            BacklogGame.backlog_id == backlog.backlog_id
+        )
+    ).all()
+    assert set(backlog_game_ids) == {1, 2}

--- a/backend/tests/features/user/test_refresh_my_backlog_handler.py
+++ b/backend/tests/features/user/test_refresh_my_backlog_handler.py
@@ -133,7 +133,7 @@ def test_handle_adds_qualifying_new_game_skips_active_game(
     current_user = _create_current_user(db_session)
     backlog = _create_backlog(db_session, current_user)
     existing_game = _create_game(db_session, 1, "Existing Game", 111)
-    new_game = _create_game(db_session, 2, "New Game", 222)
+    _create_game(db_session, 2, "New Game", 222)
     backlog_game = BacklogGame(
         backlog_id=backlog.backlog_id,
         igdb_game_id=existing_game.igdb_game_id,
@@ -202,7 +202,7 @@ def test_handle_skips_game_without_time_to_beat(
     mocker: MockerFixture,
 ):
     current_user = _create_current_user(db_session)
-    backlog = _create_backlog(db_session, current_user)
+    _create_backlog(db_session, current_user)
     _create_game(
         db_session,
         1,

--- a/frontend/src/hooks/useRefreshMyBacklog.ts
+++ b/frontend/src/hooks/useRefreshMyBacklog.ts
@@ -1,0 +1,14 @@
+import { userRefreshMyBacklog } from "@bb/client";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+export function useRefreshMyBacklog() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationKey: ["refresh-my-backlog"],
+    mutationFn: () => userRefreshMyBacklog(),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: ["myBacklog"] });
+    },
+  });
+}

--- a/frontend/src/pages/games/GameListItem.tsx
+++ b/frontend/src/pages/games/GameListItem.tsx
@@ -61,7 +61,7 @@ export function GameListItem({
         }
       >
         <ListItemText
-          secondaryTypographyProps={{ component: "div" }}
+          slotProps={{ secondary: { component: "div" } }}
           primary={
             <Stack
               direction={{ xs: "column", md: "row" }}

--- a/frontend/src/pages/my-backlog/BacklogList.tsx
+++ b/frontend/src/pages/my-backlog/BacklogList.tsx
@@ -206,10 +206,7 @@ export function BacklogList({
   };
 
   const scrollToTopOfBacklog = () => {
-    document.getElementById("active-backlog")?.scrollIntoView({
-      behavior: "smooth",
-      block: "start",
-    });
+    window.scrollTo({ top: 0, behavior: "smooth" });
   };
 
   return (

--- a/frontend/src/pages/my-backlog/BacklogList.tsx
+++ b/frontend/src/pages/my-backlog/BacklogList.tsx
@@ -109,6 +109,9 @@ const BacklogListItem = memo(function BacklogListItem({
               textDecoration: isCompleted ? "line-through" : "none",
             },
           },
+          secondary: {
+            component: "div",
+          },
         }}
       />
       <Box sx={{ display: "flex", alignItems: "center", gap: 1, ml: 2 }}>

--- a/frontend/src/pages/my-backlog/GameSortButtonGroup.tsx
+++ b/frontend/src/pages/my-backlog/GameSortButtonGroup.tsx
@@ -1,7 +1,5 @@
-import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
 import ButtonGroup from "@mui/material/ButtonGroup";
-import Typography from "@mui/material/Typography";
 import type { SortType } from "@bb/pages/my-backlog/SortType";
 
 type PropType = {
@@ -11,37 +9,25 @@ type PropType = {
 
 export function GameSortButtonGroup({ sortType, setSortType }: PropType) {
   return (
-    <Box
-      sx={{
-        display: "flex",
-        justifyContent: "space-between",
-        alignItems: "center",
-        mb: 3,
-      }}
-    >
-      <Typography variant="h4" sx={{ fontWeight: "bold" }}>
-        My Backlog
-      </Typography>
-      <ButtonGroup variant="outlined" size="small">
-        <Button
-          onClick={() => setSortType("score")}
-          variant={sortType === "score" ? "contained" : "outlined"}
-        >
-          ⭐ Highest Score
-        </Button>
-        <Button
-          onClick={() => setSortType("time")}
-          variant={sortType === "time" ? "contained" : "outlined"}
-        >
-          ⏱️ Shortest Time
-        </Button>
-        <Button
-          onClick={() => setSortType("blended")}
-          variant={sortType === "blended" ? "contained" : "outlined"}
-        >
-          🎯 Blended
-        </Button>
-      </ButtonGroup>
-    </Box>
+    <ButtonGroup variant="outlined" size="small">
+      <Button
+        onClick={() => setSortType("score")}
+        variant={sortType === "score" ? "contained" : "outlined"}
+      >
+        ⭐ Highest Score
+      </Button>
+      <Button
+        onClick={() => setSortType("time")}
+        variant={sortType === "time" ? "contained" : "outlined"}
+      >
+        ⏱️ Shortest Time
+      </Button>
+      <Button
+        onClick={() => setSortType("blended")}
+        variant={sortType === "blended" ? "contained" : "outlined"}
+      >
+        🎯 Blended
+      </Button>
+    </ButtonGroup>
   );
 }

--- a/frontend/src/pages/my-backlog/GameSortButtonGroup.tsx
+++ b/frontend/src/pages/my-backlog/GameSortButtonGroup.tsx
@@ -24,19 +24,19 @@ export function GameSortButtonGroup({ sortType, setSortType }: PropType) {
       </Typography>
       <ButtonGroup variant="outlined" size="small">
         <Button
-          onClick={() => setSortType(sortType === "score" ? null : "score")}
+          onClick={() => setSortType("score")}
           variant={sortType === "score" ? "contained" : "outlined"}
         >
           ⭐ Highest Score
         </Button>
         <Button
-          onClick={() => setSortType(sortType === "time" ? null : "time")}
+          onClick={() => setSortType("time")}
           variant={sortType === "time" ? "contained" : "outlined"}
         >
           ⏱️ Shortest Time
         </Button>
         <Button
-          onClick={() => setSortType(sortType === "blended" ? null : "blended")}
+          onClick={() => setSortType("blended")}
           variant={sortType === "blended" ? "contained" : "outlined"}
         >
           🎯 Blended

--- a/frontend/src/pages/my-backlog/MyBacklog.tsx
+++ b/frontend/src/pages/my-backlog/MyBacklog.tsx
@@ -1,9 +1,11 @@
 import { useCallback, useMemo, useState } from "react";
+import Button from "@mui/material/Button";
 import Typography from "@mui/material/Typography";
 import Box from "@mui/material/Box";
 
 import { useGetMyBacklog } from "@bb/hooks/useGetMyBacklog";
 import { useCreateMyBacklog } from "@bb/hooks/useCreateMyBacklog";
+import { useRefreshMyBacklog } from "@bb/hooks/useRefreshMyBacklog";
 import { useUpdateBacklogGame } from "@bb/hooks/useUpdateBacklogGame";
 import type { BacklogGameRow } from "@bb/client";
 import { createBlendedComparator } from "@bb/pages/my-backlog/blended-comparator";
@@ -25,6 +27,8 @@ export function MyBacklog() {
     isPending: isUpdating,
     variables: updateVariables,
   } = useUpdateBacklogGame();
+  const { mutate: refreshBacklog, isPending: isRefreshing } =
+    useRefreshMyBacklog();
   const [sortType, setSortType] = useState<SortType>("score");
   const [showCreating, setShowCreating] = useState(false);
   const [completedInSessionIds, setCompletedInSessionIds] = useState<number[]>(
@@ -95,6 +99,10 @@ export function MyBacklog() {
     });
   };
 
+  const handleRefreshBacklog = () => {
+    refreshBacklog();
+  };
+
   const handleToggleCompleted = useCallback(
     (game: BacklogGameRow) => {
       const isMarkingCompleted = !game.completedOn;
@@ -162,7 +170,31 @@ export function MyBacklog() {
         <Typography>No games in your backlog.</Typography>
       ) : (
         <>
-          <GameSortButtonGroup sortType={sortType} setSortType={setSortType} />
+          <Box
+            sx={{
+              display: "flex",
+              justifyContent: "space-between",
+              alignItems: "center",
+              mb: 3,
+            }}
+          >
+            <Typography variant="h4" sx={{ fontWeight: "bold" }}>
+              My Backlog
+            </Typography>
+            <Button
+              variant="contained"
+              onClick={handleRefreshBacklog}
+              disabled={isRefreshing}
+            >
+              {isRefreshing ? "Refreshing…" : "Refresh Backlog"}
+            </Button>
+          </Box>
+          <Box sx={{ mb: 3 }}>
+            <GameSortButtonGroup
+              sortType={sortType}
+              setSortType={setSortType}
+            />
+          </Box>
           <BacklogList
             activeGames={activeGames}
             completedGames={completedGames}

--- a/frontend/src/pages/my-backlog/MyBacklog.tsx
+++ b/frontend/src/pages/my-backlog/MyBacklog.tsx
@@ -25,7 +25,7 @@ export function MyBacklog() {
     isPending: isUpdating,
     variables: updateVariables,
   } = useUpdateBacklogGame();
-  const [sortType, setSortType] = useState<SortType>(null);
+  const [sortType, setSortType] = useState<SortType>("score");
   const [showCreating, setShowCreating] = useState(false);
   const [completedInSessionIds, setCompletedInSessionIds] = useState<number[]>(
     [],

--- a/frontend/src/pages/my-backlog/MyBacklog.tsx
+++ b/frontend/src/pages/my-backlog/MyBacklog.tsx
@@ -170,6 +170,9 @@ export function MyBacklog() {
         <Typography>No games in your backlog.</Typography>
       ) : (
         <>
+          <Typography variant="h4" sx={{ fontWeight: "bold", mb: 3 }}>
+            My Backlog
+          </Typography>
           <Box
             sx={{
               display: "flex",
@@ -178,22 +181,18 @@ export function MyBacklog() {
               mb: 3,
             }}
           >
-            <Typography variant="h4" sx={{ fontWeight: "bold" }}>
-              My Backlog
-            </Typography>
+            <GameSortButtonGroup
+              sortType={sortType}
+              setSortType={setSortType}
+            />
             <Button
+              size="small"
               variant="contained"
               onClick={handleRefreshBacklog}
               disabled={isRefreshing}
             >
               {isRefreshing ? "Refreshing…" : "Refresh Backlog"}
             </Button>
-          </Box>
-          <Box sx={{ mb: 3 }}>
-            <GameSortButtonGroup
-              sortType={sortType}
-              setSortType={setSortType}
-            />
           </Box>
           <BacklogList
             activeGames={activeGames}

--- a/frontend/src/pages/my-backlog/SortType.ts
+++ b/frontend/src/pages/my-backlog/SortType.ts
@@ -1,1 +1,1 @@
-export type SortType = "score" | "time" | "blended" | null;
+export type SortType = "score" | "time" | "blended";


### PR DESCRIPTION
## Summary
Adds a "Refresh Backlog" button that lets users sync their Steam library with
their backlog, pulling in newly owned games that have both an IGDB rating and a
time-to-beat. Also fixes MUI v7 `div`-in-`p` nesting warnings and defaults the
backlog sort to "Highest Score".
## Changes
### Backend
- **New endpoint** `POST /api/user/refresh-my-backlog` — fetches the user's
  Steam owned games, resolves any new ones through IGDB, and adds qualifying
  games (those with both a `total_rating` and `time_to_beat`) to the backlog.
  Previously removed games are not re-added.
- **Tests** covering all major paths: missing backlog → 404, no new games, mixed
  new/existing, games missing rating or time-to-beat, removed games staying
  removed, and full IGDB fetch with partial qualification.
### Frontend
- **Refresh button** on the My Backlog page — disabled while loading, shows
  "Refreshing…", invalidates the backlog query on success.
- **MUI v7 fixes** — replaced deprecated `secondaryTypographyProps` with
  `slotProps={{ secondary: { component: "div" } }}` in `GameListItem` and
  `BacklogList` to fix the "div cannot appear as descendant of p" warning.
- **Default sort** changed from `null` to `"score"` — the backlog is always
  sorted, with "Highest Score" as the default.
- **Scroll behavior** — changed `scrollToTopOfBacklog` from
  `element.scrollIntoView` to `window.scrollTo` for more reliable behavior.