### PR TITLE
Show game genre on games list and my backlog pages

### DIFF
--- a/.opencode/skills/grill-me/SKILL.md
+++ b/.opencode/skills/grill-me/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: grill-me
+description: Interview the user relentlessly about a plan or design until reaching shared understanding, resolving each branch of the decision tree. Use when user wants to stress-test a plan, get grilled on their design, or mentions "grill me".
+---
+
+Interview me relentlessly about every aspect of this plan until we reach a shared understanding. Walk down each branch of the design tree, resolving dependencies between decisions one-by-one. For each question, provide your recommended answer.
+
+Ask the questions one at a time.
+
+If a question can be answered by exploring the codebase, explore the codebase instead.

--- a/backend/app/database/models.py
+++ b/backend/app/database/models.py
@@ -92,6 +92,27 @@ class IgdbGame(Base):
     time_to_beat: Mapped[Optional["IgdbGameTimeToBeat"]] = relationship(
         "IgdbGameTimeToBeat", back_populates="igdb_game", lazy="raise"
     )
+    genres: Mapped[list["IgdbGenre"]] = relationship(
+        "IgdbGenre", secondary="bb.IgdbGameGenre", lazy="raise"
+    )
+
+
+class IgdbGenre(Base):
+    __tablename__ = "IgdbGenre"
+    igdb_genre_id: Mapped[int] = mapped_column(
+        "Id", primary_key=True, autoincrement=False
+    )
+    name: Mapped[str] = mapped_column("Name", String(100))
+
+
+class IgdbGameGenre(Base):
+    __tablename__ = "IgdbGameGenre"
+    igdb_game_id: Mapped[int] = mapped_column(
+        "IgdbGameId", ForeignKey("bb.IgdbGame.Id"), primary_key=True
+    )
+    igdb_genre_id: Mapped[int] = mapped_column(
+        "IgdbGenreId", ForeignKey("bb.IgdbGenre.Id"), primary_key=True
+    )
 
 
 class IgdbExternalGame(Base):

--- a/backend/app/features/game/persist_igdb_games.py
+++ b/backend/app/features/game/persist_igdb_games.py
@@ -1,7 +1,12 @@
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
-from app.database.models import IgdbExternalGame, IgdbGame, IgdbGameTimeToBeat
+from app.database.models import (
+    IgdbExternalGame,
+    IgdbGame,
+    IgdbGameTimeToBeat,
+    IgdbGenre,
+)
 from app.infrastructure.igdb_client import IgdbGameResponse
 
 
@@ -35,6 +40,26 @@ def persist_igdb_games(db: Session, games: list[IgdbGameResponse]) -> bool:
         ).all()
     )
 
+    all_genre_ids: set[int] = set()
+    for game in games:
+        for g in game.genres:
+            all_genre_ids.add(g.id)
+
+    existing_genre_ids = set(
+        db.scalars(
+            select(IgdbGenre.igdb_genre_id).where(
+                IgdbGenre.igdb_genre_id.in_(all_genre_ids)
+            )
+        ).all()
+    )
+
+    genre_cache: dict[int, IgdbGenre] = {}
+    for genre_id in all_genre_ids:
+        if genre_id in existing_genre_ids:
+            genre_obj = db.get(IgdbGenre, genre_id)
+            assert genre_obj is not None
+            genre_cache[genre_id] = genre_obj
+
     games_to_add: list[IgdbGame] = []
     for game in games:
         if game.id in existing_game_ids:
@@ -52,6 +77,13 @@ def persist_igdb_games(db: Session, games: list[IgdbGameResponse]) -> bool:
                 igdb_game_id=game.id,
                 normally=game.time_to_beat.normally,
             )
+
+        for genre in game.genres:
+            if genre.id not in genre_cache:
+                genre_obj = IgdbGenre(igdb_genre_id=genre.id, name=genre.name)
+                db.add(genre_obj)
+                genre_cache[genre.id] = genre_obj
+            igdb_game.genres.append(genre_cache[genre.id])
 
         for external_game in game.external_games:
             parsed_uid = _parse_external_uid(external_game.uid)

--- a/backend/app/features/game/search_games_handler.py
+++ b/backend/app/features/game/search_games_handler.py
@@ -16,6 +16,7 @@ class GameSearchRow(ApiResponseModel):
     title: str
     total_rating: float | None
     time_to_beat: int | None
+    genres: list[str]
 
 
 class SearchGamesResponse(ApiResponseModel):
@@ -80,7 +81,7 @@ class SearchGamesHandler:
         stmt = (
             select(IgdbGame)
             .join(IgdbExternalGame)
-            .options(joinedload(IgdbGame.time_to_beat))
+            .options(joinedload(IgdbGame.time_to_beat), joinedload(IgdbGame.genres))
             .where(IgdbExternalGame.igdb_external_game_source_id == 1)
             .where(IgdbGame.igdb_game_id.in_(game_ids))
             .distinct()
@@ -95,4 +96,5 @@ class SearchGamesHandler:
             title=game.name,
             total_rating=game.total_rating,
             time_to_beat=game.time_to_beat.normally if game.time_to_beat else None,
+            genres=[g.name for g in game.genres],
         )

--- a/backend/app/features/user/get_my_backlog_handler.py
+++ b/backend/app/features/user/get_my_backlog_handler.py
@@ -34,15 +34,12 @@ class GetMyBacklogHandler:
         backlog_games_loader = joinedload(
             Backlog.backlog_games.and_(BacklogGame.removed_on.is_(None))
         )
+        igdb_game_loader = backlog_games_loader.joinedload(BacklogGame.igdb_game)
         stmt = (
             select(Backlog)
             .options(
-                backlog_games_loader.joinedload(BacklogGame.igdb_game).joinedload(
-                    IgdbGame.time_to_beat
-                ),
-                backlog_games_loader.joinedload(BacklogGame.igdb_game).joinedload(
-                    IgdbGame.genres
-                ),
+                igdb_game_loader.joinedload(IgdbGame.time_to_beat),
+                igdb_game_loader.joinedload(IgdbGame.genres),
             )
             .where(Backlog.app_user_id == self.current_user.app_user_id)
         )

--- a/backend/app/features/user/get_my_backlog_handler.py
+++ b/backend/app/features/user/get_my_backlog_handler.py
@@ -22,6 +22,7 @@ class BacklogGameRow(ApiResponseModel):
     total_rating: float | None
     time_to_beat: int | None
     completed_on: datetime | None
+    genres: list[str]
 
 
 class GetMyBacklogHandler:
@@ -30,12 +31,18 @@ class GetMyBacklogHandler:
         self.current_user = current_user
 
     def handle(self):
+        backlog_games_loader = joinedload(
+            Backlog.backlog_games.and_(BacklogGame.removed_on.is_(None))
+        )
         stmt = (
             select(Backlog)
             .options(
-                joinedload(Backlog.backlog_games.and_(BacklogGame.removed_on.is_(None)))
-                .joinedload(BacklogGame.igdb_game)
-                .joinedload(IgdbGame.time_to_beat)
+                backlog_games_loader.joinedload(BacklogGame.igdb_game).joinedload(
+                    IgdbGame.time_to_beat
+                ),
+                backlog_games_loader.joinedload(BacklogGame.igdb_game).joinedload(
+                    IgdbGame.genres
+                ),
             )
             .where(Backlog.app_user_id == self.current_user.app_user_id)
         )
@@ -54,6 +61,7 @@ class GetMyBacklogHandler:
                 if g.igdb_game.time_to_beat
                 else None,
                 completed_on=g.completed_on,
+                genres=[genre.name for genre in g.igdb_game.genres],
             )
             for g in backlog.backlog_games
         ]

--- a/backend/app/infrastructure/igdb_client.py
+++ b/backend/app/infrastructure/igdb_client.py
@@ -43,10 +43,16 @@ def get_igdb_wrapper(
     return IGDBWrapper(settings.twitch_client_id, access_token)
 
 
+class GenreResponse(BaseModel):
+    id: int
+    name: str
+
+
 class IgdbGameResponse(BaseModel):
     id: int
     name: str
     total_rating: float | None = None
+    genres: list[GenreResponse] = Field(default_factory=list)
     external_games: list["ExternalGameResponse"] = Field(default_factory=list)
     time_to_beat: "TimeToBeatResponse | None" = None
 
@@ -92,7 +98,7 @@ class IgdbClient:
         # Paginate through results
         while True:
             query = f"""
-                fields game.id, game.name, game.total_rating;
+                fields game.id, game.name, game.total_rating, game.genres.name;
                 where uid = ({formatted_steam_ids}) & external_game_source = 1;
                 offset {offset};
                 limit {limit};
@@ -143,7 +149,7 @@ class IgdbClient:
 
         endpoint = "games"
         query = f"""
-            fields id, name, total_rating;
+            fields id, name, total_rating, genres.name;
             search {json.dumps(normalized_name)};
             where external_games != null & external_games.external_game_source = (1);
             limit 50;

--- a/feature-artifacts/video-game-genres/video-game-genres-prd.md
+++ b/feature-artifacts/video-game-genres/video-game-genres-prd.md
@@ -1,0 +1,16 @@
+# Video Game Genres
+
+## Description
+
+Users currently see a game's title, rating, and estimated time-to-beat when browsing games or viewing their backlog. What's missing is genre — a fundamental piece of information that helps users quickly understand what kind of game they're looking at. A player might want to scan their backlog for RPGs, check whether a search result is an action game or a strategy game, or simply get a richer at-a-glance view of each title.
+
+This feature adds genre information to every game in the system. Genres are fetched automatically from IGDB whenever a game is imported (via Steam-linked search or backlog creation/refresh) and stored in the database. They appear as labeled chips next to each game in both the search results page and the backlog list. A game may belong to multiple genres (e.g., "Action", "Adventure"); all applicable genres are shown.
+
+## Acceptance Criteria
+
+- When a user searches for a game, each result shows the genre(s) that game belongs to
+- When a user views their backlog, each game in the list shows its genre(s)
+- Each genre is displayed as a distinct, visually scannable chip alongside the game's other metadata (rating, time-to-beat)
+- Genre information is automatically populated when a game is added to the system through any import path (Steam backlog creation, backlog refresh, or name search)
+- Games added to the system before this feature shipped simply have no genre chips shown — no user-visible errors or blank labels
+- No new user-facing settings, buttons, or actions are required; genres appear automatically

--- a/feature-artifacts/video-game-genres/video-game-genres-technical-implementation.md
+++ b/feature-artifacts/video-game-genres/video-game-genres-technical-implementation.md
@@ -1,0 +1,288 @@
+# Video Game Genres — Technical Implementation Plan
+
+## Goal
+
+Add genre display to games in search results and backlog views by fetching genre data from IGDB at import time, persisting it in a normalized schema, and exposing it through the API response models.
+
+## Files to Modify
+
+| File | Change |
+|---|---|
+| `backend/app/database/models.py` | Add `IgdbGenre`, `IgdbGameGenre` models; add `genres` relationship on `IgdbGame` |
+| `migrations/up/0009.sql` | Create `bb.IgdbGenre` and `bb.IgdbGameGenre` tables |
+| `backend/app/infrastructure/igdb_client.py` | Add `GenreResponse` model; add `genres.name` to IGDB query fields; add `genres` field to `IgdbGameResponse` |
+| `backend/app/features/game/persist_igdb_games.py` | Persist `IgdbGenre` rows and junction records alongside new games |
+| `backend/app/features/game/search_games_handler.py` | Add `joinedload(IgdbGame.genres)`; include `genres` in `GameSearchRow` |
+| `backend/app/features/user/get_my_backlog_handler.py` | Add `joinedload(IgdbGame.genres)`; include `genres` in `BacklogGameRow` |
+| `frontend/src/pages/games/GameListItem.tsx` | Display genre chips in the secondary metadata area |
+| `frontend/src/pages/my-backlog/BacklogList.tsx` | Display genre chips in the secondary metadata area |
+
+## Step-by-Step Instructions
+
+### Step 1 — Database migration
+
+Create `migrations/up/0009.sql`:
+
+```sql
+CREATE TABLE bb.IgdbGenre (
+    Id          INT           NOT NULL PRIMARY KEY,
+    Name        VARCHAR(100)  NOT NULL
+);
+
+CREATE TABLE bb.IgdbGameGenre (
+    IgdbGameId  INT NOT NULL REFERENCES bb.IgdbGame(Id),
+    IgdbGenreId INT NOT NULL REFERENCES bb.IgdbGenre(Id),
+    PRIMARY KEY (IgdbGameId, IgdbGenreId)
+);
+```
+
+### Step 2 — SQLAlchemy models
+
+In `backend/app/database/models.py`, add three classes:
+
+```python
+class IgdbGenre(Base):
+    __tablename__ = "IgdbGenre"
+    igdb_genre_id: Mapped[int] = mapped_column("Id", primary_key=True, autoincrement=False)
+    name: Mapped[str] = mapped_column("Name", String(100))
+
+
+class IgdbGameGenre(Base):
+    __tablename__ = "IgdbGameGenre"
+    igdb_game_id: Mapped[int] = mapped_column("IgdbGameId", ForeignKey("bb.IgdbGame.Id"), primary_key=True)
+    igdb_genre_id: Mapped[int] = mapped_column("IgdbGenreId", ForeignKey("bb.IgdbGenre.Id"), primary_key=True)
+```
+
+Add to the existing `IgdbGame` class:
+
+```python
+class IgdbGame(Base):
+    # ... existing columns ...
+    genres: Mapped[list[IgdbGenre]] = relationship(
+        "IgdbGenre", secondary="bb.IgdbGameGenre", lazy="raise"
+    )
+```
+
+### Step 3 — IGDB client response models
+
+In `backend/app/infrastructure/igdb_client.py`, add before `IgdbGameResponse`:
+
+```python
+class GenreResponse(BaseModel):
+    id: int
+    name: str
+```
+
+Add `genres` field to `IgdbGameResponse`:
+
+```python
+class IgdbGameResponse(BaseModel):
+    id: int
+    name: str
+    total_rating: float | None = None
+    genres: list[GenreResponse] = Field(default_factory=list)
+    external_games: list["ExternalGameResponse"] = Field(default_factory=list)
+    time_to_beat: "TimeToBeatResponse | None" = None
+```
+
+### Step 4 — IGDB query fields
+
+In `get_games_by_steam_id` (line 95), change:
+```
+fields game.id, game.name, game.total_rating;
+```
+to:
+```
+fields game.id, game.name, game.total_rating, game.genres.name;
+```
+
+In `search_games_by_name` (line 146), change:
+```
+fields id, name, total_rating;
+```
+to:
+```
+fields id, name, total_rating, genres.name;
+```
+
+### Step 5 — Persist genres
+
+In `persist_igdb_games.py`, add the `IgdbGenre` import to the existing import line:
+
+```python
+from app.database.models import IgdbExternalGame, IgdbGame, IgdbGameGenre, IgdbGameTimeToBeat, IgdbGenre
+```
+
+At the top of the function body, after the `games_to_add` list is initialized, build a genre cache:
+
+```python
+    all_genre_ids: set[int] = set()
+    for game in games:
+        for g in game.genres:
+            all_genre_ids.add(g.id)
+
+    existing_genre_ids = set(
+        db.scalars(
+            select(IgdbGenre.igdb_genre_id).where(IgdbGenre.igdb_genre_id.in_(all_genre_ids))
+        ).all()
+    )
+
+    genre_cache: dict[int, IgdbGenre] = {}
+    for genre_id in all_genre_ids:
+        if genre_id in existing_genre_ids:
+            genre_cache[genre_id] = db.get(IgdbGenre, genre_id)
+```
+
+Inside the loop that creates each new `IgdbGame` (after the `igdb_game` object is constructed), attach genres:
+
+```python
+        for genre in game.genres:
+            if genre.id not in genre_cache:
+                genre_obj = IgdbGenre(igdb_genre_id=genre.id, name=genre.name)
+                db.add(genre_obj)
+                genre_cache[genre.id] = genre_obj
+            igdb_game.genres.append(genre_cache[genre.id])
+```
+
+This code runs before `db.flush()` and works within the same transaction.
+
+### Step 6 — API response models
+
+In `search_games_handler.py`, add `genres` to `GameSearchRow`:
+
+```python
+class GameSearchRow(ApiResponseModel):
+    game_id: int
+    title: str
+    total_rating: float | None
+    time_to_beat: int | None
+    genres: list[str]
+```
+
+In `get_my_backlog_handler.py`, add `genres` to `BacklogGameRow`:
+
+```python
+class BacklogGameRow(ApiResponseModel):
+    backlog_game_id: int
+    game_id: int
+    title: str
+    total_rating: float | None
+    time_to_beat: int | None
+    completed_on: datetime | None
+    genres: list[str]
+```
+
+### Step 7 — Add `joinedload` to queries
+
+In `search_games_handler.py`, `_load_games_by_ids`, add `.joinedload(IgdbGame.genres)` to the options:
+
+```python
+stmt = (
+    select(IgdbGame)
+    .join(IgdbExternalGame)
+    .options(joinedload(IgdbGame.time_to_beat), joinedload(IgdbGame.genres))
+    .where(IgdbExternalGame.igdb_external_game_source_id == 1)
+    .where(IgdbGame.igdb_game_id.in_(game_ids))
+    .distinct()
+)
+```
+
+In `get_my_backlog_handler.py`, add `.joinedload(IgdbGame.genres)` to the end of the joinedload chain:
+
+```python
+stmt = (
+    select(Backlog)
+    .options(
+        joinedload(Backlog.backlog_games.and_(BacklogGame.removed_on.is_(None)))
+        .joinedload(BacklogGame.igdb_game)
+        .joinedload(IgdbGame.time_to_beat)
+        .joinedload(IgdbGame.genres)
+    )
+    .where(Backlog.app_user_id == self.current_user.app_user_id)
+)
+```
+
+### Step 8 — Build rows with genres
+
+In `search_games_handler.py`, `_build_game_search_row`:
+
+```python
+return GameSearchRow(
+    game_id=game.igdb_game_id,
+    title=game.name,
+    total_rating=game.total_rating,
+    time_to_beat=game.time_to_beat.normally if game.time_to_beat else None,
+    genres=[g.name for g in game.genres],
+)
+```
+
+In `get_my_backlog_handler.py`, the backlog-game row builder:
+
+```python
+BacklogGameRow(
+    backlog_game_id=g.backlog_game_id,
+    game_id=g.igdb_game_id,
+    title=g.igdb_game.name,
+    total_rating=g.igdb_game.total_rating,
+    time_to_beat=g.igdb_game.time_to_beat.normally if g.igdb_game.time_to_beat else None,
+    completed_on=g.completed_on,
+    genres=[g.name for g in g.igdb_game.genres],
+)
+```
+
+### Step 9 — Regenerate frontend client
+
+```bash
+cd backend && uv run python export_openapi.py && cd ../frontend && npm run genclient
+```
+
+This updates `frontend/src/client/types.gen.ts` so `GameSearchRow` and `BacklogGameRow` include `genres: string[]`.
+
+### Step 10 — Frontend: GameListItem.tsx
+
+Import `LocalOfferIcon` (or use a generic label icon) for genre chips. Add genre chips to the secondary `Stack` alongside the existing rating and time-to-beat chips:
+
+```tsx
+{game.genres.length > 0 && (
+  <>
+    {game.genres.slice(0, 3).map((genre) => (
+      <Chip key={genre} size="small" label={genre} variant="outlined" />
+    ))}
+    {game.genres.length > 3 && (
+      <Chip size="small" label={`+${game.genres.length - 3}`} variant="outlined" />
+    )}
+  </>
+)}
+```
+
+### Step 11 — Frontend: BacklogList.tsx
+
+In the `BacklogListItem` component, add genre chips after the existing `Box` containing time-to-beat and rating. Use the same chip pattern as Step 10 but adapted for the inline layout:
+
+```tsx
+{game.genres.length > 0 && (
+  <>
+    {game.genres.slice(0, 3).map((genre) => (
+      <Chip key={genre} size="small" label={genre} variant="outlined" />
+    ))}
+    {game.genres.length > 3 && (
+      <Chip size="small" label={`+${game.genres.length - 3}`} variant="outlined" />
+    )}
+  </>
+)}
+```
+
+### Step 12 — Verify
+
+```bash
+cd backend && uv run ruff check . && uv run ruff format .
+cd frontend && npm run lint && npm run build
+```
+
+## Edge Cases and Notes
+
+- **Empty genres**: If `game.genres` is empty (pre-existing game), the frontend renders no chip — no empty string, no placeholder.
+- **Multiple genres**: Limit to 3 visible chips with "+N" overflow.
+- **Genre name changes in IGDB**: Not handled. Genre names are captured at import time and never updated. IGDB genre names are highly stable.
+- **Duplicate genre IDs across games**: The `genre_cache` dict ensures a single `IgdbGenre` row per IGDB genre ID.
+- **Test fixtures**: If a test constructs `GameSearchRow` or `BacklogGameRow` directly, it will need `genres=[]` passed explicitly (required field).

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -6,7 +6,7 @@ import tseslint from "typescript-eslint";
 import { defineConfig, globalIgnores } from "eslint/config";
 
 export default defineConfig([
-  globalIgnores(["dist", "src/client/**"]),
+  globalIgnores(["dist", "src/client/**", "coverage"]),
   {
     files: ["**/*.{ts,tsx}"],
     extends: [

--- a/frontend/src/components/GenreChips.tsx
+++ b/frontend/src/components/GenreChips.tsx
@@ -1,0 +1,28 @@
+import Chip from "@mui/material/Chip";
+
+const MAX_VISIBLE_GENRES = 3;
+
+type GenreChipsProps = {
+  genres: string[];
+};
+
+export function GenreChips({ genres }: GenreChipsProps) {
+  if (genres.length === 0) {
+    return null;
+  }
+
+  return (
+    <>
+      {genres.slice(0, MAX_VISIBLE_GENRES).map((genre) => (
+        <Chip key={genre} size="small" label={genre} variant="outlined" />
+      ))}
+      {genres.length > MAX_VISIBLE_GENRES && (
+        <Chip
+          size="small"
+          label={`+${genres.length - MAX_VISIBLE_GENRES}`}
+          variant="outlined"
+        />
+      )}
+    </>
+  );
+}

--- a/frontend/src/pages/games/GameListItem.tsx
+++ b/frontend/src/pages/games/GameListItem.tsx
@@ -12,6 +12,7 @@ import Stack from "@mui/material/Stack";
 import Typography from "@mui/material/Typography";
 
 import type { GameSearchRow } from "@bb/client";
+import { GenreChips } from "@bb/components/GenreChips";
 
 type GameListItemProps = {
   addingInProgress: boolean;
@@ -97,25 +98,7 @@ export function GameListItem({
                     : "Time to beat unavailable"
                 }
               />
-              {game.genres.length > 0 && (
-                <>
-                  {game.genres.slice(0, 3).map((genre) => (
-                    <Chip
-                      key={genre}
-                      size="small"
-                      label={genre}
-                      variant="outlined"
-                    />
-                  ))}
-                  {game.genres.length > 3 && (
-                    <Chip
-                      size="small"
-                      label={`+${game.genres.length - 3}`}
-                      variant="outlined"
-                    />
-                  )}
-                </>
-              )}
+              <GenreChips genres={game.genres} />
             </Stack>
           }
         />

--- a/frontend/src/pages/games/GameListItem.tsx
+++ b/frontend/src/pages/games/GameListItem.tsx
@@ -97,6 +97,25 @@ export function GameListItem({
                     : "Time to beat unavailable"
                 }
               />
+              {game.genres.length > 0 && (
+                <>
+                  {game.genres.slice(0, 3).map((genre) => (
+                    <Chip
+                      key={genre}
+                      size="small"
+                      label={genre}
+                      variant="outlined"
+                    />
+                  ))}
+                  {game.genres.length > 3 && (
+                    <Chip
+                      size="small"
+                      label={`+${game.genres.length - 3}`}
+                      variant="outlined"
+                    />
+                  )}
+                </>
+              )}
             </Stack>
           }
         />

--- a/frontend/src/pages/games/GamesView.tsx
+++ b/frontend/src/pages/games/GamesView.tsx
@@ -50,7 +50,7 @@ export function GamesView({
   submittedQuery,
 }: GamesViewProps) {
   return (
-    <Box sx={{ maxWidth: 900, mx: "auto", mt: 4 }}>
+    <Box sx={{ mt: 4 }}>
       <Paper
         elevation={3}
         sx={{

--- a/frontend/src/pages/my-backlog/BacklogList.tsx
+++ b/frontend/src/pages/my-backlog/BacklogList.tsx
@@ -1,5 +1,6 @@
 import { memo, useState } from "react";
 import type { BacklogGameRow } from "@bb/client";
+import { GenreChips } from "@bb/components/GenreChips";
 import CheckCircleIcon from "@mui/icons-material/CheckCircle";
 import CheckCircleOutlinedIcon from "@mui/icons-material/CheckCircleOutlined";
 import Box from "@mui/material/Box";
@@ -90,25 +91,7 @@ const BacklogListItem = memo(function BacklogListItem({
                 ⭐ {Math.round(game.totalRating)}/100
               </Typography>
             )}
-            {game.genres.length > 0 && (
-              <>
-                {game.genres.slice(0, 3).map((genre) => (
-                  <Chip
-                    key={genre}
-                    size="small"
-                    label={genre}
-                    variant="outlined"
-                  />
-                ))}
-                {game.genres.length > 3 && (
-                  <Chip
-                    size="small"
-                    label={`+${game.genres.length - 3}`}
-                    variant="outlined"
-                  />
-                )}
-              </>
-            )}
+            <GenreChips genres={game.genres} />
             {isCompleted && (
               <Chip
                 icon={<CheckCircleIcon />}

--- a/frontend/src/pages/my-backlog/BacklogList.tsx
+++ b/frontend/src/pages/my-backlog/BacklogList.tsx
@@ -90,6 +90,25 @@ const BacklogListItem = memo(function BacklogListItem({
                 ⭐ {Math.round(game.totalRating)}/100
               </Typography>
             )}
+            {game.genres.length > 0 && (
+              <>
+                {game.genres.slice(0, 3).map((genre) => (
+                  <Chip
+                    key={genre}
+                    size="small"
+                    label={genre}
+                    variant="outlined"
+                  />
+                ))}
+                {game.genres.length > 3 && (
+                  <Chip
+                    size="small"
+                    label={`+${game.genres.length - 3}`}
+                    variant="outlined"
+                  />
+                )}
+              </>
+            )}
             {isCompleted && (
               <Chip
                 icon={<CheckCircleIcon />}

--- a/frontend/src/pages/my-backlog/MyBacklog.tsx
+++ b/frontend/src/pages/my-backlog/MyBacklog.tsx
@@ -152,7 +152,7 @@ export function MyBacklog() {
   );
 
   return (
-    <Box sx={{ maxWidth: 800, mx: "auto", mt: 4 }}>
+    <Box sx={{ mt: 4 }}>
       {showCreating || isCreating ? (
         <BacklogCreatingLoader />
       ) : createError ? (

--- a/frontend/tests/blended-comparator.test.ts
+++ b/frontend/tests/blended-comparator.test.ts
@@ -12,6 +12,7 @@ function createBacklogGameRow(
     timeToBeat: overrides.timeToBeat ?? null,
     totalRating: overrides.totalRating ?? null,
     completedOn: overrides.completedOn ?? null,
+    genres: overrides.genres ?? [],
   };
 }
 

--- a/frontend/tests/game-list-item.test.tsx
+++ b/frontend/tests/game-list-item.test.tsx
@@ -114,6 +114,33 @@ describe("GameListItem", () => {
     expect(container.querySelector("hr")).not.toBeInTheDocument();
   });
 
+  test("renders genre chips when genres are provided", () => {
+    renderGameListItem({
+      game: { ...defaultGame, genres: ["Action", "Roguelike"] },
+    });
+    expect(screen.getByText("Action")).toBeInTheDocument();
+    expect(screen.getByText("Roguelike")).toBeInTheDocument();
+  });
+
+  test("renders no genre chips when genres are empty", () => {
+    renderGameListItem({ game: { ...defaultGame, genres: [] } });
+    expect(screen.queryByRole("button", { name: /action/i })).toBeNull();
+  });
+
+  test("renders overflow chip when more than 3 genres", () => {
+    renderGameListItem({
+      game: {
+        ...defaultGame,
+        genres: ["Action", "RPG", "Adventure", "Strategy"],
+      },
+    });
+    expect(screen.getByText("Action")).toBeInTheDocument();
+    expect(screen.getByText("RPG")).toBeInTheDocument();
+    expect(screen.getByText("Adventure")).toBeInTheDocument();
+    expect(screen.getByText("+1")).toBeInTheDocument();
+    expect(screen.queryByText("Strategy")).toBeNull();
+  });
+
   test("calls onAddToBacklog when add button is clicked", () => {
     const onAddToBacklog = vi.fn();
     renderGameListItem({

--- a/frontend/tests/game-list-item.test.tsx
+++ b/frontend/tests/game-list-item.test.tsx
@@ -8,6 +8,7 @@ const defaultGame: GameSearchRow = {
   title: "Test Game",
   totalRating: 85,
   timeToBeat: 14400,
+  genres: [],
 };
 const noop = () => {};
 

--- a/frontend/tests/games-view.test.tsx
+++ b/frontend/tests/games-view.test.tsx
@@ -65,6 +65,7 @@ describe("GamesView", () => {
         title: "Hades II",
         totalRating: 93.5,
         timeToBeat: 43200,
+        genres: [],
       },
     ];
 
@@ -103,7 +104,13 @@ describe("GamesView", () => {
 
   test('shows "Add to backlog" button when logged in and results are present', () => {
     const results: GameSearchRow[] = [
-      { gameId: 1, title: "Hades", totalRating: 91, timeToBeat: 36000 },
+      {
+        gameId: 1,
+        title: "Hades",
+        totalRating: 91,
+        timeToBeat: 36000,
+        genres: [],
+      },
     ];
 
     const markup = renderGamesView({
@@ -118,7 +125,13 @@ describe("GamesView", () => {
 
   test('shows "In backlog" chip for a game already in the backlog', () => {
     const results: GameSearchRow[] = [
-      { gameId: 1, title: "Hades", totalRating: 91, timeToBeat: 36000 },
+      {
+        gameId: 1,
+        title: "Hades",
+        totalRating: 91,
+        timeToBeat: 36000,
+        genres: [],
+      },
     ];
 
     const markup = renderGamesView({
@@ -134,7 +147,13 @@ describe("GamesView", () => {
 
   test('shows "Adding…" button while a game is being added', () => {
     const results: GameSearchRow[] = [
-      { gameId: 1, title: "Hades", totalRating: 91, timeToBeat: 36000 },
+      {
+        gameId: 1,
+        title: "Hades",
+        totalRating: 91,
+        timeToBeat: 36000,
+        genres: [],
+      },
     ];
 
     const markup = renderGamesView({
@@ -170,8 +189,20 @@ describe("GamesView", () => {
 
   test("renders multiple results with pluralized text", () => {
     const results: GameSearchRow[] = [
-      { gameId: 1, title: "Hades", totalRating: 91, timeToBeat: 36000 },
-      { gameId: 2, title: "Hades II", totalRating: 93, timeToBeat: 43200 },
+      {
+        gameId: 1,
+        title: "Hades",
+        totalRating: 91,
+        timeToBeat: 36000,
+        genres: [],
+      },
+      {
+        gameId: 2,
+        title: "Hades II",
+        totalRating: 93,
+        timeToBeat: 43200,
+        genres: [],
+      },
     ];
 
     const markup = renderGamesView({

--- a/frontend/tests/games-view.test.tsx
+++ b/frontend/tests/games-view.test.tsx
@@ -187,6 +187,26 @@ describe("GamesView", () => {
     expect(markup).toContain("Custom error message");
   });
 
+  test("renders genre chips for search results", () => {
+    const results: GameSearchRow[] = [
+      {
+        gameId: 1,
+        title: "Hades",
+        totalRating: 91,
+        timeToBeat: 36000,
+        genres: ["Action", "Roguelike"],
+      },
+    ];
+
+    const markup = renderGamesView({
+      hasSearched: true,
+      results,
+    });
+
+    expect(markup).toContain("Action");
+    expect(markup).toContain("Roguelike");
+  });
+
   test("renders multiple results with pluralized text", () => {
     const results: GameSearchRow[] = [
       {

--- a/frontend/tests/games.test.tsx
+++ b/frontend/tests/games.test.tsx
@@ -177,6 +177,7 @@ describe("Games", () => {
               title: "Hades",
               totalRating: 93,
               timeToBeat: 36000,
+              genres: [],
             },
           ],
         },

--- a/migrations/up/0009.sql
+++ b/migrations/up/0009.sql
@@ -1,0 +1,10 @@
+CREATE TABLE bb.IgdbGenre (
+    Id          INT           NOT NULL PRIMARY KEY,
+    Name        VARCHAR(100)  NOT NULL
+);
+
+CREATE TABLE bb.IgdbGameGenre (
+    IgdbGameId  INT NOT NULL REFERENCES bb.IgdbGame(Id),
+    IgdbGenreId INT NOT NULL REFERENCES bb.IgdbGenre(Id),
+    PRIMARY KEY (IgdbGameId, IgdbGenreId)
+);

--- a/migrations/up/0009.sql
+++ b/migrations/up/0009.sql
@@ -1,10 +1,10 @@
-CREATE TABLE bb.IgdbGenre (
-    Id          INT           NOT NULL PRIMARY KEY,
-    Name        VARCHAR(100)  NOT NULL
+create table bb.IgdbGenre (
+    Id          int           not null primary key,
+    Name        varchar(100)  not null
 );
 
-CREATE TABLE bb.IgdbGameGenre (
-    IgdbGameId  INT NOT NULL REFERENCES bb.IgdbGame(Id),
-    IgdbGenreId INT NOT NULL REFERENCES bb.IgdbGenre(Id),
-    PRIMARY KEY (IgdbGameId, IgdbGenreId)
+create table bb.IgdbGameGenre (
+    IgdbGameId  int not null references bb.IgdbGame(Id),
+    IgdbGenreId int not null references bb.IgdbGenre(Id),
+    primary key (IgdbGameId, IgdbGenreId)
 );


### PR DESCRIPTION
## Show video game genres & better screen utilization

Adds IGDB genre data to the backlog pipeline and displays genres as chips on
both the Games search and My Backlog pages. Also removes the hard `maxWidth`
constraint on both pages so content fills available space on wider screens.

### Backend

- New `IgdbGenre` and `IgdbGameGenre` ORM models + migration `0009.sql`
  creating the `bb.IgdbGenre` and `bb.IgdbGameGenre` tables
- Extended `IgdbGameResponse` schema with a `genres` field and updated IGDB API
  queries to request `game.genres.name`
- `persist_igdb_games.py` now persists genre relationships when importing games
  from IGDB
- `search_games_handler` and `get_my_backlog_handler` include genres in their
  API response rows

### Frontend

- `GameListItem` and `BacklogListItem` display up to 3 genre chips (with a
  `+N` overflow chip when there are more)
- Removed `maxWidth` / `mx: "auto"` from `GamesView` and `MyBacklog` so the
  content uses the full viewport width

### Docs & tooling

- PRD and technical implementation docs for the genre feature under
  `docs/video-game-genres/`
- New `grill-me` opencode skill for design review interviews
- Updated test fixtures to include the `genres: []` field where needed