### PR TITLE
Skeleton loaders

### DIFF
--- a/feature-artifacts/skeleton-loaders/skeleton-loaders.md
+++ b/feature-artifacts/skeleton-loaders/skeleton-loaders.md
@@ -1,0 +1,119 @@
+# Skeleton Loaders
+
+## Goal
+
+Replace text-based and spinner loading states with MUI Skeleton pulse animations across three areas: MyBacklog initial load, search results, and backlog refresh.
+
+## Decisions
+
+- **Animation**: `pulse` (MUI default)
+- **MyBacklog skeleton**: Fixed 8 rows (6 active + 2 completed) with section headers
+- **Search skeleton**: 5 rows, uniform chip widths
+- **Refresh indicator**: `LinearProgress` bar below toolbar
+- **Code organization**: Dedicated skeleton files as siblings to their parent components
+
+## Step 1: Create `BacklogListSkeleton.tsx`
+
+**New file:** `frontend/src/pages/my-backlog/BacklogListSkeleton.tsx`
+
+Mirrors the exact layout of `BacklogList.tsx` but replaces real game data with Skeleton placeholders.
+
+Structure:
+```
+Stack spacing={3}
+  Paper (Active Backlog section)
+    Box header (same gradient styling as BacklogList.tsx:221-258)
+      - Skeleton variant="text" width={180} height={32}   // mirrors "Active Backlog" h6
+      - Skeleton variant="text" width={140} height={20}   // mirrors "{N} games to work through"
+    List
+      6x BacklogListItemSkeleton
+        ListItem (py: 2, px: 2 - matches BacklogListItem)
+          ListItemText
+            primary: Skeleton variant="text" width="45%" height={20}    // title
+            secondary: Box with flex row
+              Skeleton variant="text" width={40} height={16}           // "⏱️ Nh"
+              Skeleton variant="text" width={55} height={16}           // "⭐ N/100"
+              3x Skeleton variant="rounded" width={60} height={24}     // genre chips
+          Box (action buttons area)
+            Skeleton variant="rounded" width={110} height={32}         // "Mark complete" button
+            Skeleton variant="circular" width={40} height={40}         // delete icon
+          Divider (between rows, not on last)
+
+  Paper (Completed Games section - same as BacklogList.tsx:266-315)
+    Box header (success-tinted gradient)
+      - Skeleton variant="text" width={200} height={32}   // "Completed Games"
+      - Skeleton variant="text" width={160} height={20}   // "{N} completed games"
+    List
+      2x BacklogListItemSkeleton (same structure, no action buttons)
+```
+
+## Step 2: Create `SearchResultsSkeleton.tsx`
+
+**New file:** `frontend/src/pages/games/SearchResultsSkeleton.tsx`
+
+Mirrors the layout of `SearchResults.tsx` + `GameListItem.tsx`.
+
+Structure:
+```
+Paper variant="outlined"
+  Box header
+    Typography "Searching for {query}"        // real text, already available
+    Typography "Pulling matching games..."    // real text
+  List
+    5x GameListItemSkeleton
+      ListItem (py: 2.5, px: 3 - matches GameListItem.tsx:39)
+        ListItemText
+          primary: Stack (direction row)
+            Skeleton variant="text" width="40%" height={28}    // title (h6 size)
+          secondary: Stack (direction row, spacing 1, mt: 1.5)
+            Skeleton variant="rounded" width={90} height={28}  // rating chip
+            Skeleton variant="rounded" width={80} height={28}  // time chip
+            3x Skeleton variant="rounded" width={60} height={24} // genre chips (uniform)
+        secondaryAction:
+          Skeleton variant="rounded" width={120} height={32}   // "Add to backlog" button
+      Divider (between rows, not on last)
+```
+
+## Step 3: Update `MyBacklog.tsx`
+
+**Modify:** `frontend/src/pages/my-backlog/MyBacklog.tsx`
+
+1. Import `BacklogListSkeleton` (new file)
+2. Import `LinearProgress` from `@mui/material/LinearProgress`
+3. Replace line 168 (`<Typography>Loading…</Typography>`) with:
+   ```tsx
+   <BacklogListSkeleton />
+   ```
+4. Add LinearProgress for refresh state — insert between the toolbar `Box` (line 176-196) and the `BacklogList` (line 197):
+   ```tsx
+   {isRefreshing && <LinearProgress sx={{ mt: -2, mb: 2 }} />}
+   ```
+
+## Step 4: Update `GamesView.tsx`
+
+**Modify:** `frontend/src/pages/games/GamesView.tsx`
+
+1. Import `SearchResultsSkeleton` (new file)
+2. Replace lines 120-138 (the `isPending` spinner block) with:
+   ```tsx
+   {isPending ? (
+     <SearchResultsSkeleton submittedQuery={submittedQuery} />
+   ) : null}
+   ```
+
+## Files Changed Summary
+
+| File | Action | Description |
+|---|---|---|
+| `frontend/src/pages/my-backlog/BacklogListSkeleton.tsx` | **Create** | 8-row skeleton matching BacklogList layout |
+| `frontend/src/pages/games/SearchResultsSkeleton.tsx` | **Create** | 5-row skeleton matching SearchResults layout |
+| `frontend/src/pages/my-backlog/MyBacklog.tsx` | **Modify** | Replace "Loading..." text with skeleton, add LinearProgress for refresh |
+| `frontend/src/pages/games/GamesView.tsx` | **Modify** | Replace CircularProgress spinner with SearchResultsSkeleton |
+
+## Verification
+
+1. `cd frontend && npm run build` — confirm no TypeScript errors
+2. `cd frontend && npm run lint` — confirm no lint errors
+3. Manual test: navigate to `/my-backlog` while not logged in (or with slow network) — should see skeleton pulse
+4. Manual test: search for a game — should see 5 skeleton rows replace the spinner
+5. Manual test: click "Refresh Backlog" — should see LinearProgress bar appear

--- a/frontend/src/pages/games/GamesView.tsx
+++ b/frontend/src/pages/games/GamesView.tsx
@@ -1,6 +1,5 @@
 import Alert from "@mui/material/Alert";
 import Box from "@mui/material/Box";
-import CircularProgress from "@mui/material/CircularProgress";
 import Link from "@mui/material/Link";
 import Paper from "@mui/material/Paper";
 import Stack from "@mui/material/Stack";
@@ -11,6 +10,7 @@ import { Link as RouterLink } from "react-router";
 import type { GameSearchRow } from "@bb/client";
 import { SearchForm } from "@bb/pages/games/SearchForm";
 import { SearchResults } from "@bb/pages/games/SearchResults";
+import { SearchResultsSkeleton } from "@bb/pages/games/SearchResultsSkeleton";
 
 type GamesViewProps = {
   addedGameIds: Set<number>;
@@ -118,23 +118,7 @@ export function GamesView({
       ) : null}
 
       {isPending ? (
-        <Paper
-          variant="outlined"
-          sx={{ p: 3, borderRadius: 3, bgcolor: "background.paper" }}
-        >
-          <Stack direction="row" spacing={2} sx={{ alignItems: "center" }}>
-            <CircularProgress size={32} />
-            <Box>
-              <Typography variant="h6" gutterBottom>
-                Searching for "{submittedQuery}"
-              </Typography>
-              <Typography color="text.secondary">
-                Pulling matching games from the local catalog and IGDB if
-                needed.
-              </Typography>
-            </Box>
-          </Stack>
-        </Paper>
+        <SearchResultsSkeleton submittedQuery={submittedQuery} />
       ) : null}
 
       {hasSearched && !isPending && !isError ? (

--- a/frontend/src/pages/games/SearchResultsSkeleton.tsx
+++ b/frontend/src/pages/games/SearchResultsSkeleton.tsx
@@ -13,9 +13,7 @@ function GameListItemSkeleton({ isLast }: { isLast: boolean }) {
     <Box>
       <ListItem
         sx={{ py: 2.5, px: 3 }}
-        secondaryAction={
-          <Skeleton variant="rounded" width={120} height={32} />
-        }
+        secondaryAction={<Skeleton variant="rounded" width={120} height={32} />}
       >
         <ListItemText
           slotProps={{ secondary: { component: "div" } }}
@@ -46,9 +44,14 @@ function GameListItemSkeleton({ isLast }: { isLast: boolean }) {
 
 export function SearchResultsSkeleton({
   submittedQuery,
-}: { submittedQuery: string }) {
+}: {
+  submittedQuery: string;
+}) {
   return (
-    <Paper variant="outlined" sx={{ borderRadius: 3, bgcolor: "background.paper" }}>
+    <Paper
+      variant="outlined"
+      sx={{ borderRadius: 3, bgcolor: "background.paper" }}
+    >
       <Box
         sx={{
           px: 3,
@@ -59,7 +62,9 @@ export function SearchResultsSkeleton({
             "linear-gradient(180deg, rgba(25,118,210,0.08) 0%, rgba(25,118,210,0.02) 100%)",
         }}
       >
-        <Typography variant="h6">Searching for &quot;{submittedQuery}&quot;</Typography>
+        <Typography variant="h6">
+          Searching for &quot;{submittedQuery}&quot;
+        </Typography>
         <Typography variant="body2" color="text.secondary">
           Pulling matching games from the local catalog and IGDB if needed.
         </Typography>

--- a/frontend/src/pages/games/SearchResultsSkeleton.tsx
+++ b/frontend/src/pages/games/SearchResultsSkeleton.tsx
@@ -1,0 +1,74 @@
+import Box from "@mui/material/Box";
+import Divider from "@mui/material/Divider";
+import List from "@mui/material/List";
+import ListItem from "@mui/material/ListItem";
+import ListItemText from "@mui/material/ListItemText";
+import Paper from "@mui/material/Paper";
+import Skeleton from "@mui/material/Skeleton";
+import Stack from "@mui/material/Stack";
+import Typography from "@mui/material/Typography";
+
+function GameListItemSkeleton({ isLast }: { isLast: boolean }) {
+  return (
+    <Box>
+      <ListItem
+        sx={{ py: 2.5, px: 3 }}
+        secondaryAction={
+          <Skeleton variant="rounded" width={120} height={32} />
+        }
+      >
+        <ListItemText
+          slotProps={{ secondary: { component: "div" } }}
+          primary={
+            <Stack direction="row" spacing={1.5} sx={{ alignItems: "center" }}>
+              <Skeleton variant="text" width="40%" height={28} />
+            </Stack>
+          }
+          secondary={
+            <Stack
+              direction="row"
+              spacing={1}
+              sx={{ mt: 1.5, flexWrap: "wrap", rowGap: 1 }}
+            >
+              <Skeleton variant="rounded" width={90} height={28} />
+              <Skeleton variant="rounded" width={80} height={28} />
+              <Skeleton variant="rounded" width={60} height={24} />
+              <Skeleton variant="rounded" width={60} height={24} />
+              <Skeleton variant="rounded" width={60} height={24} />
+            </Stack>
+          }
+        />
+      </ListItem>
+      {!isLast ? <Divider /> : null}
+    </Box>
+  );
+}
+
+export function SearchResultsSkeleton({
+  submittedQuery,
+}: { submittedQuery: string }) {
+  return (
+    <Paper variant="outlined" sx={{ borderRadius: 3, bgcolor: "background.paper" }}>
+      <Box
+        sx={{
+          px: 3,
+          py: 2,
+          borderBottom: "1px solid",
+          borderColor: "divider",
+          background:
+            "linear-gradient(180deg, rgba(25,118,210,0.08) 0%, rgba(25,118,210,0.02) 100%)",
+        }}
+      >
+        <Typography variant="h6">Searching for &quot;{submittedQuery}&quot;</Typography>
+        <Typography variant="body2" color="text.secondary">
+          Pulling matching games from the local catalog and IGDB if needed.
+        </Typography>
+      </Box>
+      <List sx={{ py: 0 }}>
+        {Array.from({ length: 5 }).map((_, i) => (
+          <GameListItemSkeleton key={i} isLast={i === 4} />
+        ))}
+      </List>
+    </Paper>
+  );
+}

--- a/frontend/src/pages/my-backlog/BacklogListSkeleton.tsx
+++ b/frontend/src/pages/my-backlog/BacklogListSkeleton.tsx
@@ -1,0 +1,116 @@
+import Box from "@mui/material/Box";
+import Divider from "@mui/material/Divider";
+import List from "@mui/material/List";
+import ListItem from "@mui/material/ListItem";
+import ListItemText from "@mui/material/ListItemText";
+import Paper from "@mui/material/Paper";
+import Skeleton from "@mui/material/Skeleton";
+import Stack from "@mui/material/Stack";
+
+function BacklogListItemSkeleton({ noActions }: { noActions?: boolean }) {
+  return (
+    <ListItem sx={{ py: 2, px: 2 }}>
+      <ListItemText
+        primary={<Skeleton variant="text" width="45%" height={20} />}
+        secondary={
+          <Box sx={{ display: "flex", flexWrap: "wrap", gap: 1, mt: 0.75 }}>
+            <Skeleton variant="text" width={40} height={16} />
+            <Skeleton variant="text" width={55} height={16} />
+            <Skeleton variant="rounded" width={60} height={24} />
+            <Skeleton variant="rounded" width={60} height={24} />
+            <Skeleton variant="rounded" width={60} height={24} />
+          </Box>
+        }
+        slotProps={{ secondary: { component: "div" } }}
+      />
+      {!noActions && (
+        <Box sx={{ display: "flex", alignItems: "center", gap: 1, ml: 2 }}>
+          <Skeleton variant="rounded" width={110} height={32} />
+          <Skeleton variant="circular" width={40} height={40} />
+        </Box>
+      )}
+    </ListItem>
+  );
+}
+
+export function BacklogListSkeleton() {
+  return (
+    <Stack spacing={3}>
+      <Paper elevation={2} sx={{ borderRadius: 2, overflow: "hidden" }}>
+        <Box
+          sx={{
+            px: 3,
+            py: 2,
+            borderBottom: "1px solid",
+            borderColor: "divider",
+            background:
+              "linear-gradient(180deg, rgba(25,118,210,0.08) 0%, rgba(25,118,210,0.02) 100%)",
+          }}
+        >
+          <Box
+            sx={{
+              display: "flex",
+              justifyContent: "space-between",
+              alignItems: "center",
+              gap: 2,
+              flexWrap: "wrap",
+            }}
+          >
+            <Box>
+              <Skeleton variant="text" width={180} height={32} />
+              <Skeleton variant="text" width={140} height={20} />
+            </Box>
+          </Box>
+        </Box>
+        <List sx={{ py: 0 }}>
+          {Array.from({ length: 6 }).map((_, i) => (
+            <Box key={i}>
+              <BacklogListItemSkeleton />
+              {i < 5 && <Divider />}
+            </Box>
+          ))}
+        </List>
+      </Paper>
+
+      <Paper
+        elevation={1}
+        sx={{
+          borderRadius: 2,
+          overflow: "hidden",
+          border: "1px solid",
+          borderColor: "success.light",
+          backgroundColor: "rgba(76, 175, 80, 0.04)",
+        }}
+      >
+        <Box
+          sx={{
+            px: 3,
+            py: 2,
+            borderBottom: "1px solid",
+            borderColor: "success.light",
+            background:
+              "linear-gradient(180deg, rgba(76,175,80,0.12) 0%, rgba(76,175,80,0.04) 100%)",
+            display: "flex",
+            justifyContent: "space-between",
+            alignItems: "center",
+            gap: 2,
+            flexWrap: "wrap",
+          }}
+        >
+          <Box>
+            <Skeleton variant="text" width={200} height={32} />
+            <Skeleton variant="text" width={160} height={20} />
+          </Box>
+        </Box>
+        <List sx={{ py: 0 }}>
+          {Array.from({ length: 2 }).map((_, i) => (
+            <Box key={i}>
+              <BacklogListItemSkeleton noActions />
+              {i < 1 && <Divider />}
+            </Box>
+          ))}
+        </List>
+      </Paper>
+    </Stack>
+  );
+}

--- a/frontend/src/pages/my-backlog/MyBacklog.tsx
+++ b/frontend/src/pages/my-backlog/MyBacklog.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useMemo, useState } from "react";
 import Button from "@mui/material/Button";
+import LinearProgress from "@mui/material/LinearProgress";
 import Typography from "@mui/material/Typography";
 import Box from "@mui/material/Box";
 
@@ -12,6 +13,7 @@ import { createBlendedComparator } from "@bb/pages/my-backlog/blended-comparator
 import { GameSortButtonGroup } from "@bb/pages/my-backlog/GameSortButtonGroup";
 import type { SortType } from "@bb/pages/my-backlog/SortType";
 import { BacklogList } from "@bb/pages/my-backlog/BacklogList";
+import { BacklogListSkeleton } from "@bb/pages/my-backlog/BacklogListSkeleton";
 import { BacklogCreatingLoader } from "@bb/pages/my-backlog/BacklogCreatingLoader";
 import { CreateBacklogPrompt } from "@bb/pages/my-backlog/CreateBacklogPrompt";
 
@@ -165,7 +167,7 @@ export function MyBacklog() {
       ) : is404 ? (
         <CreateBacklogPrompt onCreateBacklog={handleCreateBacklog} />
       ) : !isSuccess ? (
-        <Typography>Loading…</Typography>
+        <BacklogListSkeleton />
       ) : games.length === 0 ? (
         <Typography>No games in your backlog.</Typography>
       ) : (
@@ -194,6 +196,7 @@ export function MyBacklog() {
               {isRefreshing ? "Refreshing…" : "Refresh Backlog"}
             </Button>
           </Box>
+          {isRefreshing && <LinearProgress sx={{ mt: -2, mb: 2 }} />}
           <BacklogList
             activeGames={activeGames}
             completedGames={completedGames}

--- a/frontend/tests/backlog-list-skeleton.test.tsx
+++ b/frontend/tests/backlog-list-skeleton.test.tsx
@@ -1,0 +1,61 @@
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { BacklogListSkeleton } from "../src/pages/my-backlog/BacklogListSkeleton";
+
+function renderSkeleton() {
+  return renderToStaticMarkup(<BacklogListSkeleton />);
+}
+
+describe("BacklogListSkeleton", () => {
+  test("renders skeleton elements", () => {
+    const markup = renderSkeleton();
+    expect(markup).toContain("MuiSkeleton");
+  });
+
+  test("renders 6 active skeleton rows", () => {
+    const markup = renderSkeleton();
+    const listItems = markup.split("<li");
+    expect(listItems.length - 1).toBe(8);
+  });
+
+  test("renders completed games section", () => {
+    const markup = renderSkeleton();
+    expect(markup).toContain("MuiPaper-elevation1");
+  });
+
+  test("renders action button skeletons for active rows", () => {
+    const markup = renderSkeleton();
+    expect(markup).toContain("width:110px");
+    expect(markup).toContain("width:40px");
+  });
+
+  test("renders dividers between active rows", () => {
+    const markup = renderSkeleton();
+    const dividers = markup.split("<hr");
+    expect(dividers.length - 1).toBe(6);
+  });
+
+  test("renders title skeleton placeholders", () => {
+    const markup = renderSkeleton();
+    expect(markup).toContain("width:180px");
+    expect(markup).toContain("width:200px");
+  });
+
+  test("renders subtitle skeleton placeholders", () => {
+    const markup = renderSkeleton();
+    expect(markup).toContain("width:140px");
+    expect(markup).toContain("width:160px");
+  });
+
+  test("renders time and rating skeleton placeholders", () => {
+    const markup = renderSkeleton();
+    expect(markup).toContain("width:40px");
+    expect(markup).toContain("width:55px");
+  });
+
+  test("renders genre chip skeleton placeholders", () => {
+    const markup = renderSkeleton();
+    const chipSkeletons = markup.split("width:60px");
+    expect(chipSkeletons.length - 1).toBeGreaterThanOrEqual(3);
+  });
+});

--- a/frontend/tests/backlog-list.test.tsx
+++ b/frontend/tests/backlog-list.test.tsx
@@ -1,0 +1,213 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+
+import type { BacklogGameRow } from "../src/client";
+import { BacklogList } from "../src/pages/my-backlog/BacklogList";
+
+const noop = () => {};
+
+const activeGame: BacklogGameRow = {
+  backlogGameId: 1,
+  gameId: 10,
+  title: "Active Game",
+  totalRating: 85,
+  timeToBeat: 36000,
+  genres: ["Action"],
+  completedOn: null,
+  removedOn: null,
+  addedOn: "2025-01-01T00:00:00Z",
+  igdbId: 100,
+  steamAppId: 1000,
+};
+
+const completedGame: BacklogGameRow = {
+  ...activeGame,
+  backlogGameId: 2,
+  gameId: 20,
+  title: "Completed Game",
+  completedOn: "2025-06-01T00:00:00Z",
+};
+
+function renderBacklogList(
+  overrides: Partial<Parameters<typeof BacklogList>[0]> = {},
+) {
+  return render(
+    <BacklogList
+      activeGames={[activeGame]}
+      completedGames={[]}
+      onToggleCompleted={noop}
+      onRemoveGame={noop}
+      updatingBacklogGameId={null}
+      {...overrides}
+    />,
+  );
+}
+
+describe("BacklogList", () => {
+  test("renders active games section header", () => {
+    renderBacklogList();
+    expect(screen.getByText("Active Backlog")).toBeInTheDocument();
+  });
+
+  test("renders active game count", () => {
+    renderBacklogList({ activeGames: [activeGame] });
+    expect(screen.getByText("1 game to work through")).toBeInTheDocument();
+  });
+
+  test("renders pluralized game count", () => {
+    const game2 = { ...activeGame, backlogGameId: 3, title: "Game 2" };
+    renderBacklogList({ activeGames: [activeGame, game2] });
+    expect(screen.getByText("2 games to work through")).toBeInTheDocument();
+  });
+
+  test("renders game title", () => {
+    renderBacklogList();
+    expect(screen.getByText("Active Game")).toBeInTheDocument();
+  });
+
+  test("renders time to beat", () => {
+    renderBacklogList();
+    expect(screen.getByText("⏱️ 10h")).toBeInTheDocument();
+  });
+
+  test("renders rating", () => {
+    renderBacklogList();
+    expect(screen.getByText("⭐ 85/100")).toBeInTheDocument();
+  });
+
+  test("renders genre chips", () => {
+    renderBacklogList();
+    expect(screen.getByText("Action")).toBeInTheDocument();
+  });
+
+  test("renders Mark complete button for active game", () => {
+    renderBacklogList();
+    expect(
+      screen.getByRole("button", { name: /mark complete/i }),
+    ).toBeInTheDocument();
+  });
+
+  test("renders delete button for active game", () => {
+    renderBacklogList();
+    expect(
+      screen.getByRole("button", { name: /remove from backlog/i }),
+    ).toBeInTheDocument();
+  });
+
+  test("calls onToggleCompleted when Mark complete is clicked", () => {
+    const onToggleCompleted = vi.fn();
+    renderBacklogList({ onToggleCompleted });
+    fireEvent.click(screen.getByRole("button", { name: /mark complete/i }));
+    expect(onToggleCompleted).toHaveBeenCalledWith(activeGame);
+  });
+
+  test("opens remove dialog when delete button is clicked", () => {
+    renderBacklogList();
+    fireEvent.click(
+      screen.getByRole("button", { name: /remove from backlog/i }),
+    );
+    expect(
+      screen.getByText("Remove game from backlog?"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Remove Active Game from your backlog/),
+    ).toBeInTheDocument();
+  });
+
+  test("calls onRemoveGame when remove is confirmed", () => {
+    const onRemoveGame = vi.fn();
+    renderBacklogList({ onRemoveGame });
+    fireEvent.click(
+      screen.getByRole("button", { name: /remove from backlog/i }),
+    );
+    fireEvent.click(screen.getByRole("button", { name: /^remove$/i }));
+    expect(onRemoveGame).toHaveBeenCalledWith(activeGame);
+  });
+
+  test("closes dialog when cancel is clicked", () => {
+    renderBacklogList();
+    fireEvent.click(
+      screen.getByRole("button", { name: /remove from backlog/i }),
+    );
+    expect(
+      screen.getByText("Remove game from backlog?"),
+    ).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /cancel/i }));
+    expect(
+      screen.getByText("Remove game from backlog?"),
+    ).not.toBeVisible();
+  });
+
+  test("does not render completed section when no completed games", () => {
+    renderBacklogList({ completedGames: [] });
+    expect(screen.queryByText("Completed Games")).not.toBeInTheDocument();
+  });
+
+  test("renders completed games section when completed games exist", () => {
+    renderBacklogList({ completedGames: [completedGame] });
+    expect(screen.getByText("Completed Games")).toBeInTheDocument();
+    expect(screen.getByText("Completed Game")).toBeInTheDocument();
+  });
+
+  test("renders Completed chip for completed games", () => {
+    renderBacklogList({ completedGames: [completedGame] });
+    expect(screen.getAllByText("Completed").length).toBeGreaterThanOrEqual(1);
+  });
+
+  test("renders Completed button for completed games", () => {
+    renderBacklogList({ completedGames: [completedGame] });
+    expect(
+      screen.getAllByRole("button", { name: /completed/i }).length,
+    ).toBeGreaterThanOrEqual(1);
+  });
+
+  test("shows Jump to completed games button when completed games exist", () => {
+    renderBacklogList({ completedGames: [completedGame] });
+    expect(
+      screen.getByRole("button", { name: /jump to completed games/i }),
+    ).toBeInTheDocument();
+  });
+
+  test("does not show Jump to completed games button when no completed games", () => {
+    renderBacklogList({ completedGames: [] });
+    expect(
+      screen.queryByRole("button", { name: /jump to completed games/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  test("disables buttons when game is being updated", () => {
+    renderBacklogList({ updatingBacklogGameId: 1 });
+    expect(
+      screen.getByRole("button", { name: /mark complete/i }),
+    ).toBeDisabled();
+    expect(
+      screen.getByRole("button", { name: /remove from backlog/i }),
+    ).toBeDisabled();
+  });
+
+  test("renders dividers between items", () => {
+    const game2 = { ...activeGame, backlogGameId: 3, title: "Game 2" };
+    const { container } = renderBacklogList({
+      activeGames: [activeGame, game2],
+    });
+    const dividers = container.querySelectorAll("hr");
+    expect(dividers.length).toBeGreaterThanOrEqual(1);
+  });
+
+  test("renders completed game count with singular form", () => {
+    renderBacklogList({ completedGames: [completedGame] });
+    expect(screen.getByText("1 completed game")).toBeInTheDocument();
+  });
+
+  test("renders completed game count with plural form", () => {
+    const game2 = { ...completedGame, backlogGameId: 4, title: "Game 2" };
+    renderBacklogList({ completedGames: [completedGame, game2] });
+    expect(screen.getByText("2 completed games")).toBeInTheDocument();
+  });
+
+  test("shows Jump to top of backlog button in completed section", () => {
+    renderBacklogList({ completedGames: [completedGame] });
+    expect(
+      screen.getByRole("button", { name: /jump to top of backlog/i }),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/tests/backlog-list.test.tsx
+++ b/frontend/tests/backlog-list.test.tsx
@@ -105,9 +105,7 @@ describe("BacklogList", () => {
     fireEvent.click(
       screen.getByRole("button", { name: /remove from backlog/i }),
     );
-    expect(
-      screen.getByText("Remove game from backlog?"),
-    ).toBeInTheDocument();
+    expect(screen.getByText("Remove game from backlog?")).toBeInTheDocument();
     expect(
       screen.getByText(/Remove Active Game from your backlog/),
     ).toBeInTheDocument();
@@ -128,13 +126,9 @@ describe("BacklogList", () => {
     fireEvent.click(
       screen.getByRole("button", { name: /remove from backlog/i }),
     );
-    expect(
-      screen.getByText("Remove game from backlog?"),
-    ).toBeInTheDocument();
+    expect(screen.getByText("Remove game from backlog?")).toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: /cancel/i }));
-    expect(
-      screen.getByText("Remove game from backlog?"),
-    ).not.toBeVisible();
+    expect(screen.getByText("Remove game from backlog?")).not.toBeVisible();
   });
 
   test("does not render completed section when no completed games", () => {

--- a/frontend/tests/my-backlog.test.tsx
+++ b/frontend/tests/my-backlog.test.tsx
@@ -1,0 +1,297 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { MemoryRouter } from "react-router";
+
+const mockGetMyBacklog = vi.hoisted(() => vi.fn());
+const mockCreateMyBacklog = vi.hoisted(() => vi.fn());
+const mockRefreshMyBacklog = vi.hoisted(() => vi.fn());
+const mockUpdateBacklogGame = vi.hoisted(() => vi.fn());
+
+vi.mock("@bb/hooks/useGetMyBacklog", () => ({
+  useGetMyBacklog: mockGetMyBacklog,
+}));
+vi.mock("@bb/hooks/useCreateMyBacklog", () => ({
+  useCreateMyBacklog: mockCreateMyBacklog,
+}));
+vi.mock("@bb/hooks/useRefreshMyBacklog", () => ({
+  useRefreshMyBacklog: mockRefreshMyBacklog,
+}));
+vi.mock("@bb/hooks/useUpdateBacklogGame", () => ({
+  useUpdateBacklogGame: mockUpdateBacklogGame,
+}));
+
+const { MyBacklog } = await import("../src/pages/my-backlog/MyBacklog");
+
+function setupDefaultMocks() {
+  mockGetMyBacklog.mockReturnValue({
+    data: undefined,
+    isSuccess: false,
+    refetch: vi.fn(),
+  });
+  mockCreateMyBacklog.mockReturnValue({
+    mutate: vi.fn(),
+    isPending: false,
+    isError: false,
+  });
+  mockRefreshMyBacklog.mockReturnValue({
+    mutate: vi.fn(),
+    isPending: false,
+  });
+  mockUpdateBacklogGame.mockReturnValue({
+    mutate: vi.fn(),
+    isPending: false,
+    variables: undefined,
+  });
+}
+
+function renderMyBacklog() {
+  return renderToStaticMarkup(
+    <MemoryRouter>
+      <MyBacklog />
+    </MemoryRouter>,
+  );
+}
+
+describe("MyBacklog", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupDefaultMocks();
+  });
+
+  test("renders skeleton when data is loading", () => {
+    const markup = renderMyBacklog();
+    expect(markup).toContain("MuiSkeleton");
+  });
+
+  test("renders 404 create prompt when backlog not found", () => {
+    mockGetMyBacklog.mockReturnValue({
+      data: { response: { status: 404 } },
+      isSuccess: false,
+      refetch: vi.fn(),
+    });
+
+    const markup = renderMyBacklog();
+    expect(markup).toContain("Create My Backlog");
+  });
+
+  test("renders create backlog loader when creating", () => {
+    mockCreateMyBacklog.mockReturnValue({
+      mutate: vi.fn(),
+      isPending: true,
+      isError: false,
+    });
+
+    const markup = renderMyBacklog();
+    expect(markup).toContain("Creating your backlog");
+  });
+
+  test("renders error message when create fails", () => {
+    mockCreateMyBacklog.mockReturnValue({
+      mutate: vi.fn(),
+      isPending: false,
+      isError: true,
+    });
+
+    const markup = renderMyBacklog();
+    expect(markup).toContain("Failed to create backlog");
+  });
+
+  test("renders empty state when no games", () => {
+    mockGetMyBacklog.mockReturnValue({
+      data: { data: { games: [] }, response: { status: 200 } },
+      isSuccess: true,
+      refetch: vi.fn(),
+    });
+
+    const markup = renderMyBacklog();
+    expect(markup).toContain("No games in your backlog");
+  });
+
+  test("renders My Backlog header when games exist", () => {
+    mockGetMyBacklog.mockReturnValue({
+      data: {
+        data: {
+          games: [
+            {
+              backlogGameId: 1,
+              gameId: 10,
+              title: "Hades",
+              totalRating: 90,
+              timeToBeat: 36000,
+              genres: ["Action"],
+              completedOn: null,
+              removedOn: null,
+              addedOn: "2025-01-01T00:00:00Z",
+              igdbId: 100,
+              steamAppId: 1000,
+            },
+          ],
+        },
+        response: { status: 200 },
+      },
+      isSuccess: true,
+      refetch: vi.fn(),
+    });
+
+    const markup = renderMyBacklog();
+    expect(markup).toContain("My Backlog");
+    expect(markup).toContain("Hades");
+  });
+
+  test("renders Refresh Backlog button", () => {
+    mockGetMyBacklog.mockReturnValue({
+      data: {
+        data: {
+          games: [
+            {
+              backlogGameId: 1,
+              gameId: 10,
+              title: "Hades",
+              totalRating: 90,
+              timeToBeat: 36000,
+              genres: [],
+              completedOn: null,
+              removedOn: null,
+              addedOn: "2025-01-01T00:00:00Z",
+              igdbId: 100,
+              steamAppId: 1000,
+            },
+          ],
+        },
+        response: { status: 200 },
+      },
+      isSuccess: true,
+      refetch: vi.fn(),
+    });
+
+    const markup = renderMyBacklog();
+    expect(markup).toContain("Refresh Backlog");
+  });
+
+  test("shows Refreshing text when refresh is in progress", () => {
+    mockRefreshMyBacklog.mockReturnValue({
+      mutate: vi.fn(),
+      isPending: true,
+    });
+    mockGetMyBacklog.mockReturnValue({
+      data: {
+        data: {
+          games: [
+            {
+              backlogGameId: 1,
+              gameId: 10,
+              title: "Hades",
+              totalRating: 90,
+              timeToBeat: 36000,
+              genres: [],
+              completedOn: null,
+              removedOn: null,
+              addedOn: "2025-01-01T00:00:00Z",
+              igdbId: 100,
+              steamAppId: 1000,
+            },
+          ],
+        },
+        response: { status: 200 },
+      },
+      isSuccess: true,
+      refetch: vi.fn(),
+    });
+
+    const markup = renderMyBacklog();
+    expect(markup).toContain("Refreshing…");
+  });
+
+  test("shows LinearProgress during refresh", () => {
+    mockRefreshMyBacklog.mockReturnValue({
+      mutate: vi.fn(),
+      isPending: true,
+    });
+    mockGetMyBacklog.mockReturnValue({
+      data: {
+        data: {
+          games: [
+            {
+              backlogGameId: 1,
+              gameId: 10,
+              title: "Hades",
+              totalRating: 90,
+              timeToBeat: 36000,
+              genres: [],
+              completedOn: null,
+              removedOn: null,
+              addedOn: "2025-01-01T00:00:00Z",
+              igdbId: 100,
+              steamAppId: 1000,
+            },
+          ],
+        },
+        response: { status: 200 },
+      },
+      isSuccess: true,
+      refetch: vi.fn(),
+    });
+
+    const markup = renderMyBacklog();
+    expect(markup).toContain("MuiLinearProgress");
+  });
+
+  test("does not show LinearProgress when not refreshing", () => {
+    mockGetMyBacklog.mockReturnValue({
+      data: {
+        data: {
+          games: [
+            {
+              backlogGameId: 1,
+              gameId: 10,
+              title: "Hades",
+              totalRating: 90,
+              timeToBeat: 36000,
+              genres: [],
+              completedOn: null,
+              removedOn: null,
+              addedOn: "2025-01-01T00:00:00Z",
+              igdbId: 100,
+              steamAppId: 1000,
+            },
+          ],
+        },
+        response: { status: 200 },
+      },
+      isSuccess: true,
+      refetch: vi.fn(),
+    });
+
+    const markup = renderMyBacklog();
+    expect(markup).not.toContain("MuiLinearProgress");
+  });
+
+  test("renders sort button group", () => {
+    mockGetMyBacklog.mockReturnValue({
+      data: {
+        data: {
+          games: [
+            {
+              backlogGameId: 1,
+              gameId: 10,
+              title: "Hades",
+              totalRating: 90,
+              timeToBeat: 36000,
+              genres: [],
+              completedOn: null,
+              removedOn: null,
+              addedOn: "2025-01-01T00:00:00Z",
+              igdbId: 100,
+              steamAppId: 1000,
+            },
+          ],
+        },
+        response: { status: 200 },
+      },
+      isSuccess: true,
+      refetch: vi.fn(),
+    });
+
+    const markup = renderMyBacklog();
+    expect(markup).toContain("Score");
+  });
+});

--- a/frontend/tests/search-results-skeleton.test.tsx
+++ b/frontend/tests/search-results-skeleton.test.tsx
@@ -1,0 +1,54 @@
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { SearchResultsSkeleton } from "../src/pages/games/SearchResultsSkeleton";
+
+function renderSkeleton(query = "hades") {
+  return renderToStaticMarkup(
+    <SearchResultsSkeleton submittedQuery={query} />,
+  );
+}
+
+describe("SearchResultsSkeleton", () => {
+  test("renders the searching header with query", () => {
+    const markup = renderSkeleton("hades");
+    expect(markup).toContain("Searching for &quot;hades&quot;");
+  });
+
+  test("renders the subtitle text", () => {
+    const markup = renderSkeleton();
+    expect(markup).toContain("Pulling matching games");
+  });
+
+  test("renders 5 skeleton list items", () => {
+    const markup = renderSkeleton();
+    const listItems = markup.split("<li");
+    expect(listItems.length - 1).toBe(5);
+  });
+
+  test("renders title skeleton placeholders", () => {
+    const markup = renderSkeleton();
+    expect(markup).toContain("width:40%");
+  });
+
+  test("renders chip skeleton placeholders", () => {
+    const markup = renderSkeleton();
+    expect(markup).toContain("width:90px");
+    expect(markup).toContain("width:80px");
+  });
+
+  test("renders add button skeleton placeholders", () => {
+    const markup = renderSkeleton();
+    expect(markup).toContain("width:120px");
+  });
+
+  test("renders dividers between items except last", () => {
+    const markup = renderSkeleton();
+    const dividers = markup.split("<hr");
+    expect(dividers.length - 1).toBe(4);
+  });
+
+  test("renders with different query", () => {
+    const markup = renderSkeleton("zelda");
+    expect(markup).toContain("Searching for &quot;zelda&quot;");
+  });
+});

--- a/frontend/tests/search-results-skeleton.test.tsx
+++ b/frontend/tests/search-results-skeleton.test.tsx
@@ -3,9 +3,7 @@ import { renderToStaticMarkup } from "react-dom/server";
 import { SearchResultsSkeleton } from "../src/pages/games/SearchResultsSkeleton";
 
 function renderSkeleton(query = "hades") {
-  return renderToStaticMarkup(
-    <SearchResultsSkeleton submittedQuery={query} />,
-  );
+  return renderToStaticMarkup(<SearchResultsSkeleton submittedQuery={query} />);
 }
 
 describe("SearchResultsSkeleton", () => {

--- a/frontend/tests/search-results.test.tsx
+++ b/frontend/tests/search-results.test.tsx
@@ -1,0 +1,128 @@
+import { render, screen } from "@testing-library/react";
+
+import type { GameSearchRow } from "../src/client";
+import { SearchResults } from "../src/pages/games/SearchResults";
+
+const noop = () => {};
+
+const game: GameSearchRow = {
+  gameId: 1,
+  title: "Hades",
+  totalRating: 91,
+  timeToBeat: 36000,
+  genres: ["Action", "Roguelike"],
+};
+
+function renderSearchResults(
+  overrides: Partial<Parameters<typeof SearchResults>[0]> = {},
+) {
+  return render(
+    <SearchResults
+      addedGameIds={new Set()}
+      addingGameId={null}
+      backlogGameIds={new Set()}
+      hasBacklog={true}
+      isLoggedIn={true}
+      onAddToBacklog={noop}
+      results={[game]}
+      submittedQuery="hades"
+      {...overrides}
+    />,
+  );
+}
+
+describe("SearchResults", () => {
+  test("renders empty state when no results", () => {
+    renderSearchResults({ results: [] });
+    expect(
+      screen.getByText('No games found for "hades".'),
+    ).toBeInTheDocument();
+  });
+
+  test("renders Search Results header", () => {
+    renderSearchResults();
+    expect(screen.getByText("Search Results")).toBeInTheDocument();
+  });
+
+  test("renders result count with singular form", () => {
+    renderSearchResults({ results: [game] });
+    expect(
+      screen.getByText('1 game matching "hades"'),
+    ).toBeInTheDocument();
+  });
+
+  test("renders result count with plural form", () => {
+    const game2 = { ...game, gameId: 2, title: "Hades II" };
+    renderSearchResults({ results: [game, game2] });
+    expect(
+      screen.getByText('2 games matching "hades"'),
+    ).toBeInTheDocument();
+  });
+
+  test("renders game title", () => {
+    renderSearchResults();
+    expect(screen.getByText("Hades")).toBeInTheDocument();
+  });
+
+  test("renders Add to backlog button when logged in with backlog", () => {
+    renderSearchResults({
+      isLoggedIn: true,
+      hasBacklog: true,
+      inBacklog: false,
+    });
+    expect(
+      screen.getByRole("button", { name: /add to backlog/i }),
+    ).toBeInTheDocument();
+  });
+
+  test("does not render Add to backlog button when not logged in", () => {
+    renderSearchResults({ isLoggedIn: false });
+    expect(
+      screen.queryByRole("button", { name: /add to backlog/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  test("does not render Add to backlog button when no backlog", () => {
+    renderSearchResults({ isLoggedIn: true, hasBacklog: false });
+    expect(
+      screen.queryByRole("button", { name: /add to backlog/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  test("renders In backlog chip for game already in backlog", () => {
+    renderSearchResults({
+      backlogGameIds: new Set([1]),
+    });
+    expect(screen.getByText("In backlog")).toBeInTheDocument();
+  });
+
+  test("renders In backlog chip for game recently added", () => {
+    renderSearchResults({
+      addedGameIds: new Set([1]),
+    });
+    expect(screen.getByText("In backlog")).toBeInTheDocument();
+  });
+
+  test("renders Adding… when game is being added", () => {
+    renderSearchResults({
+      addingGameId: 1,
+    });
+    expect(screen.getByText("Adding…")).toBeInTheDocument();
+  });
+
+  test("renders genre chips for results", () => {
+    renderSearchResults();
+    expect(screen.getByText("Action")).toBeInTheDocument();
+    expect(screen.getByText("Roguelike")).toBeInTheDocument();
+  });
+
+  test("renders rating chip", () => {
+    renderSearchResults();
+    expect(screen.getByText("91/100 rating")).toBeInTheDocument();
+  });
+
+  test("renders time to beat chip", () => {
+    renderSearchResults();
+    expect(screen.getByText("10h to beat")).toBeInTheDocument();
+  });
+});

--- a/frontend/tests/search-results.test.tsx
+++ b/frontend/tests/search-results.test.tsx
@@ -34,9 +34,7 @@ function renderSearchResults(
 describe("SearchResults", () => {
   test("renders empty state when no results", () => {
     renderSearchResults({ results: [] });
-    expect(
-      screen.getByText('No games found for "hades".'),
-    ).toBeInTheDocument();
+    expect(screen.getByText('No games found for "hades".')).toBeInTheDocument();
   });
 
   test("renders Search Results header", () => {
@@ -46,17 +44,13 @@ describe("SearchResults", () => {
 
   test("renders result count with singular form", () => {
     renderSearchResults({ results: [game] });
-    expect(
-      screen.getByText('1 game matching "hades"'),
-    ).toBeInTheDocument();
+    expect(screen.getByText('1 game matching "hades"')).toBeInTheDocument();
   });
 
   test("renders result count with plural form", () => {
     const game2 = { ...game, gameId: 2, title: "Hades II" };
     renderSearchResults({ results: [game, game2] });
-    expect(
-      screen.getByText('2 games matching "hades"'),
-    ).toBeInTheDocument();
+    expect(screen.getByText('2 games matching "hades"')).toBeInTheDocument();
   });
 
   test("renders game title", () => {


### PR DESCRIPTION
## Summary

Replace text-based and spinner loading states with MUI Skeleton pulse animations across three areas: MyBacklog initial load, search results, and backlog refresh.

## Changes

### New files
- **`BacklogListSkeleton.tsx`** — 8-row skeleton (6 active + 2 completed) mirroring `BacklogList` layout with section headers, genre chips, and action button placeholders
- **`SearchResultsSkeleton.tsx`** — 5-row skeleton mirroring `SearchResults` + `GameListItem` layout with title, chip, and "Add to backlog" button placeholders

### Modified files
- **`MyBacklog.tsx`** — Replaced `<Typography>Loading…</Typography>` with `<BacklogListSkeleton />`; added `<LinearProgress>` bar below toolbar during backlog refresh
- **`GamesView.tsx`** — Replaced `CircularProgress` spinner with `<SearchResultsSkeleton />`; removed unused `CircularProgress` import

### New test files
- **`backlog-list.test.tsx`** — 24 tests covering active/completed rendering, callbacks, remove dialog, dividers, and updating state
- **`search-results.test.tsx`** — 14 tests covering empty state, header, add/backlog chips, genre chips, and action buttons
- **`backlog-list-skeleton.test.tsx`** — 9 tests covering row counts, skeleton placeholders, dividers, and section structure
- **`search-results-skeleton.test.tsx`** — 8 tests covering query header, subtitle, row count, skeleton widths, and dividers
- **`my-backlog.test.tsx`** — 11 tests covering loading skeleton, 404, create/error states, refresh progress, and sort controls