### PR TITLE
Fix logout bugs and make auth improvements

### DIFF
--- a/backend/app/features/auth/get_current_user.py
+++ b/backend/app/features/auth/get_current_user.py
@@ -18,11 +18,11 @@ class User:
     last_name: str | None
 
 
-def get_current_user(request: Request, db: DbSession):
+def get_current_user(request: Request, db: DbSession) -> User | None:
     session_key = request.cookies.get("session_key")
 
     if session_key is None:
-        raise HTTPException(status.HTTP_401_UNAUTHORIZED)
+        return None
 
     now = datetime.now(tz=timezone.utc)
     stmt = (
@@ -33,7 +33,7 @@ def get_current_user(request: Request, db: DbSession):
     )
     app_session = db.scalars(stmt).one_or_none()
     if app_session is None:
-        raise HTTPException(status.HTTP_401_UNAUTHORIZED)
+        return None
 
     app_user = app_session.app_user
 
@@ -46,4 +46,13 @@ def get_current_user(request: Request, db: DbSession):
     )
 
 
-CurrentUser: TypeAlias = Annotated[User, Depends(get_current_user)]
+CurrentUser: TypeAlias = Annotated[User | None, Depends(get_current_user)]
+
+
+def require_current_user(current_user: CurrentUser) -> User:
+    if current_user is None:
+        raise HTTPException(status.HTTP_401_UNAUTHORIZED)
+    return current_user
+
+
+RequiredCurrentUser: TypeAlias = Annotated[User, Depends(require_current_user)]

--- a/backend/app/features/backlog_game/add_backlog_game_handler.py
+++ b/backend/app/features/backlog_game/add_backlog_game_handler.py
@@ -4,7 +4,7 @@ from sqlalchemy import select
 from app.database.engine import DbSession
 from app.database.models import Backlog, BacklogGame, IgdbGame
 from app.features.api_model import ApiRequestModel, ApiResponseModel
-from app.features.auth.get_current_user import CurrentUser
+from app.features.auth.get_current_user import RequiredCurrentUser
 
 
 class AddBacklogGameRequest(ApiRequestModel):
@@ -16,7 +16,7 @@ class AddBacklogGameResponse(ApiResponseModel):
 
 
 class AddBacklogGameHandler:
-    def __init__(self, db: DbSession, current_user: CurrentUser):
+    def __init__(self, db: DbSession, current_user: RequiredCurrentUser):
         self.db = db
         self.current_user = current_user
 

--- a/backend/app/features/backlog_game/update_backlog_game_handler.py
+++ b/backend/app/features/backlog_game/update_backlog_game_handler.py
@@ -7,7 +7,7 @@ from sqlalchemy.orm import joinedload
 from app.database.engine import DbSession
 from app.database.models import BacklogGame
 from app.features.api_model import ApiRequestModel, ApiResponseModel
-from app.features.auth.get_current_user import CurrentUser
+from app.features.auth.get_current_user import RequiredCurrentUser
 
 
 class UpdateBacklogGameRequest(ApiRequestModel):
@@ -20,7 +20,7 @@ class UpdateBacklogGameResponse(ApiResponseModel):
 
 
 class UpdateBacklogGameHandler:
-    def __init__(self, db: DbSession, current_user: CurrentUser):
+    def __init__(self, db: DbSession, current_user: RequiredCurrentUser):
         self.db = db
         self.current_user = current_user
 

--- a/backend/app/features/user/create_my_backlog_handler.py
+++ b/backend/app/features/user/create_my_backlog_handler.py
@@ -8,7 +8,7 @@ from app.database.models import (
     IgdbGame,
 )
 from app.features.api_model import ApiResponseModel
-from app.features.auth.get_current_user import CurrentUser
+from app.features.auth.get_current_user import RequiredCurrentUser
 from app.features.game.persist_igdb_games import persist_igdb_games
 from app.infrastructure.igdb_client import IgdbClientDep
 from app.infrastructure.steam_client import SteamClientDep
@@ -23,7 +23,7 @@ class CreateMyBacklogHandler:
         self,
         db: DbSession,
         steam: SteamClientDep,
-        current_user: CurrentUser,
+        current_user: RequiredCurrentUser,
         igdb_client: IgdbClientDep,
     ):
         self.db = db

--- a/backend/app/features/user/get_me_handler.py
+++ b/backend/app/features/user/get_me_handler.py
@@ -12,7 +12,9 @@ class GetMeHandler:
     def __init__(self, current_user: CurrentUser):
         self.current_user = current_user
 
-    def handle(self):
+    def handle(self) -> GetMeResponse | None:
+        if self.current_user is None:
+            return None
         return GetMeResponse(
             app_user_id=self.current_user.app_user_id,
             steam_id=self.current_user.steam_id,

--- a/backend/app/features/user/get_my_backlog_handler.py
+++ b/backend/app/features/user/get_my_backlog_handler.py
@@ -7,7 +7,7 @@ from sqlalchemy.orm import joinedload
 from app.database.engine import DbSession
 from app.database.models import Backlog, BacklogGame, IgdbGame
 from app.features.api_model import ApiResponseModel
-from app.features.auth.get_current_user import CurrentUser
+from app.features.auth.get_current_user import RequiredCurrentUser
 
 
 class GetMyBacklogResponse(ApiResponseModel):
@@ -27,7 +27,7 @@ class BacklogGameRow(ApiResponseModel):
 
 
 class GetMyBacklogHandler:
-    def __init__(self, db: DbSession, current_user: CurrentUser):
+    def __init__(self, db: DbSession, current_user: RequiredCurrentUser):
         self.db = db
         self.current_user = current_user
 

--- a/backend/app/features/user/refresh_my_backlog_handler.py
+++ b/backend/app/features/user/refresh_my_backlog_handler.py
@@ -9,7 +9,7 @@ from app.database.models import (
     IgdbGame,
 )
 from app.features.api_model import ApiResponseModel
-from app.features.auth.get_current_user import CurrentUser
+from app.features.auth.get_current_user import RequiredCurrentUser
 from app.features.game.persist_igdb_games import persist_igdb_games
 from app.infrastructure.igdb_client import IgdbClientDep
 from app.infrastructure.steam_client import SteamClientDep
@@ -25,7 +25,7 @@ class RefreshMyBacklogHandler:
         self,
         db: DbSession,
         steam: SteamClientDep,
-        current_user: CurrentUser,
+        current_user: RequiredCurrentUser,
         igdb_client: IgdbClientDep,
     ):
         self.db = db

--- a/backend/app/features/user/user_router.py
+++ b/backend/app/features/user/user_router.py
@@ -18,7 +18,7 @@ user_router = APIRouter(tags=["User"])
 
 
 @user_router.get("/api/user/me")
-def get_me(handler: GetMeHandler = Depends()) -> GetMeResponse:
+def get_me(handler: GetMeHandler = Depends()) -> GetMeResponse | None:
     return handler.handle()
 
 

--- a/frontend/src/hooks/useCurrentUser.ts
+++ b/frontend/src/hooks/useCurrentUser.ts
@@ -4,7 +4,7 @@ import { userGetMe } from "@bb/client";
 export function useCurrentUser(retry: boolean | number = 3) {
   return useQuery({
     queryKey: ["currentUser"],
-    queryFn: () => userGetMe({ throwOnError: true }),
+    queryFn: () => userGetMe(),
     retry: retry,
   });
 }

--- a/frontend/src/hooks/useGetMyBacklog.ts
+++ b/frontend/src/hooks/useGetMyBacklog.ts
@@ -1,10 +1,11 @@
 import { useQuery } from "@tanstack/react-query";
 import { userGetMyBacklog } from "@bb/client";
 
-export function useGetMyBacklog() {
+export function useGetMyBacklog(enabled = true) {
   return useQuery({
     queryKey: ["myBacklog"],
     queryFn: () => userGetMyBacklog(),
     retry: false,
+    enabled,
   });
 }

--- a/frontend/src/hooks/useLogOut.ts
+++ b/frontend/src/hooks/useLogOut.ts
@@ -1,8 +1,14 @@
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { authLogout } from "@bb/client";
 
 export function useLogoutMutation() {
+  const queryClient = useQueryClient();
+
   return useMutation({
     mutationFn: () => authLogout(),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: ["currentUser"] });
+      queryClient.removeQueries({ queryKey: ["myBacklog"] });
+    },
   });
 }

--- a/frontend/src/hooks/useSearchGames.ts
+++ b/frontend/src/hooks/useSearchGames.ts
@@ -11,6 +11,7 @@ export function useSearchGames() {
     mutationFn: ({ query }: SearchGamesParams) =>
       gameSearchGames({
         query: { query },
+        throwOnError: true,
       }),
   });
 }

--- a/frontend/src/hooks/useSearchGames.ts
+++ b/frontend/src/hooks/useSearchGames.ts
@@ -11,7 +11,6 @@ export function useSearchGames() {
     mutationFn: ({ query }: SearchGamesParams) =>
       gameSearchGames({
         query: { query },
-        throwOnError: true,
       }),
   });
 }

--- a/frontend/src/pages/games/Games.tsx
+++ b/frontend/src/pages/games/Games.tsx
@@ -21,15 +21,16 @@ export function Games() {
     isPending: searchIsPending,
     mutate: searchGames,
   } = useSearchGames();
-  const { data: userData } = useCurrentUser(false);
-  const { data: backlogData, isPending: isBacklogLoading } = useGetMyBacklog();
+  const { isSuccess, data: userData } = useCurrentUser(false);
+  const isLoggedIn = isSuccess && !!userData?.data;
+  const { data: backlogData, isPending: isBacklogLoading } =
+    useGetMyBacklog(isLoggedIn);
   const {
     mutate: addBacklogGame,
     isPending: isAdding,
     variables: addVariables,
   } = useAddBacklogGame();
 
-  const isLoggedIn = !!userData?.data;
   const hasBacklog = !!backlogData?.data;
 
   const backlogGameIds = useMemo(() => {

--- a/frontend/src/pages/games/GamesView.tsx
+++ b/frontend/src/pages/games/GamesView.tsx
@@ -95,7 +95,7 @@ export function GamesView({
 
       {isLoggedIn && !hasBacklog && !isBacklogLoading ? (
         <Alert severity="error" sx={{ mb: 3 }}>
-          You don&apos;t have a backlog yet.{" "}
+          You don't have a backlog yet.{" "}
           <Link component={RouterLink} to="/my-backlog">
             Create your backlog
           </Link>

--- a/frontend/tests/games.test.tsx
+++ b/frontend/tests/games.test.tsx
@@ -101,6 +101,7 @@ describe("Games", () => {
 
   test("renders backlog creation prompt when logged in without backlog", () => {
     mockUseCurrentUser.mockReturnValue({
+      isSuccess: true,
       data: { data: { steamId: "12345" } },
     });
     mockUseGetMyBacklog.mockReturnValue({
@@ -114,6 +115,7 @@ describe("Games", () => {
 
   test("does not show backlog alert while backlog is loading", () => {
     mockUseCurrentUser.mockReturnValue({
+      isSuccess: true,
       data: { data: { steamId: "12345" } },
     });
     mockUseGetMyBacklog.mockReturnValue({
@@ -132,6 +134,7 @@ describe("Games", () => {
 
   test("computes backlogGameIds from backlog data", () => {
     mockUseCurrentUser.mockReturnValue({
+      isSuccess: true,
       data: { data: { steamId: "12345" } },
     });
     mockUseGetMyBacklog.mockReturnValue({
@@ -188,6 +191,7 @@ describe("Games", () => {
       mutate,
     });
     mockUseCurrentUser.mockReturnValue({
+      isSuccess: true,
       data: { data: { steamId: "12345" } },
     });
     mockUseGetMyBacklog.mockReturnValue({


### PR DESCRIPTION
Fix auth bugs:
1. Logout on home page does not immediately reflect new auth state
2. "You don't have a backlog yet" on games page incorrectly showing after logging out.

General auth improvements:
1. Remove unnecessary throw on error config
2. Fix console errors on every page navigation from always calling /api/user/me
3. Improved user handling on the backend - have two injectable types, CurrentUser and RequiredCurrentUser